### PR TITLE
Migrate to Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ RUN apt-get update && \
      ca-certificates \
      curl \
      software-properties-common \
-     unzip
-
-RUN curl -fsSL https://apt.dockerproject.org/gpg | apt-key add - && \
+     unzip && \
+    curl -fsSL https://apt.dockerproject.org/gpg | apt-key add - && \
     add-apt-repository "deb https://apt.dockerproject.org/repo/ \
        debian-$(lsb_release -cs) \
        main" && \
-    apt-get update && apt-get -y install docker-engine
+    apt-get update && apt-get -y install docker-engine && \
+    apt-get clean
 
 RUN cd /tmp && \
     curl -sSLO https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,33 @@
-# Used to create docker image for running the commands invoked by the stubs in ../scripts/.
+FROM python:3
 
-FROM centos:7
+ENV TERRAFORM_VERSION=0.8.7
+ENV TERRAGRUNT_VERSION=v0.10.2
 
-ENV TERRAFORM_VERSION=0.8.5
-ENV TERRAGRUNT_VERSION=v0.9.9
-ENV DOCKER_COMPOSE_VERSION=1.10.1
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+     apt-transport-https \
+     ca-certificates \
+     curl \
+     software-properties-common \
+     unzip
 
-ADD yum.repos.d/docker.repo /etc/yum.repos.d/
-ADD ./requirements.txt /infra/requirements.txt
+RUN curl -fsSL https://apt.dockerproject.org/gpg | apt-key add - && \
+    add-apt-repository "deb https://apt.dockerproject.org/repo/ \
+       debian-$(lsb_release -cs) \
+       main" && \
+    apt-get update && apt-get -y install docker-engine
 
-RUN yum install -y epel-release && \
-    yum install -y bash ca-certificates curl docker-engine gawk git git openssl python-pip unzip wget && \
-    cd /tmp && \
+RUN cd /tmp && \
     curl -sSLO https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
     mv terragrunt_linux_amd64 /usr/local/bin/terragrunt && \
     curl -sSLO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_*_linux_amd64.zip -d /usr/bin && \
     rm -rf /tmp/* && \
     rm -rf /var/tmp/* && \
-    chmod 755 /usr/local/bin/terragrunt && \
-    yum group install -y "Development Tools" && yum install -y python-devel && \
-    pip install -r /infra/requirements.txt && \
-    curl -L "https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose && \
-    yum group remove "Development Tools" -y && yum clean all
+    chmod 755 /usr/local/bin/terragrunt
+
+ADD ./requirements.txt /cdflow/requirements.txt
+RUN pip install -r /cdflow/requirements.txt
 
 ADD . /cdflow
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
-FROM python:2
+FROM python:3
 
-RUN mkdir /infra
-WORKDIR /infra
+RUN mkdir /cdflow
+WORKDIR /cdflow
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -103,7 +103,7 @@ def get_component_name(component_name):
     if component_name:
         return component_name
     remote = check_output(['git', 'config', 'remote.origin.url'])
-    name = remote.strip().split('/')[-1]
+    name = remote.decode('utf-8').strip().split('/')[-1]
     if name.endswith('.git'):
         return name[:-4]
     return name

--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -78,7 +78,7 @@ class Release(object):
 
         username, password = b64decode(
             response['authorizationData'][0]['authorizationToken']
-        ).split(':')
+        ).decode('utf-8').split(':')
 
         proxy_endpoint = response['authorizationData'][0]['proxyEndpoint']
 

--- a/cdflow_commands/terragrunt.py
+++ b/cdflow_commands/terragrunt.py
@@ -103,10 +103,12 @@ class S3BucketFactory(object):
         )
 
     def _generate_bucket_name(self, attempt):
+        parts = map(str, [self._aws_region, self._account_id, attempt])
+        concatenated = ''.join(parts)
         return '{}-{}'.format(
             NAME_PREFIX,
             sha1(
-                self._aws_region + str(self._account_id) + str(attempt)
+                concatenated.encode('utf-8')
             ).hexdigest()[:12]
         )
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,7 +1,7 @@
-import json
-
 import unittest
 
+import json
+from io import TextIOWrapper
 from datetime import datetime
 from collections import namedtuple
 from string import printable
@@ -25,7 +25,7 @@ class TestReleaseCLI(unittest.TestCase):
         self, check_call, mock_open,
         Session_from_config, Session_from_cli, mock_os
     ):
-        mock_metadata_file = MagicMock(spec=file)
+        mock_metadata_file = MagicMock(spec=TextIOWrapper)
         metadata = {
             'TEAM': 'dummy-team',
             'TYPE': 'docker',
@@ -34,7 +34,7 @@ class TestReleaseCLI(unittest.TestCase):
         }
         mock_metadata_file.read.return_value = json.dumps(metadata)
 
-        mock_dev_file = MagicMock(spec=file)
+        mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
                 'account_id': 123456789
@@ -42,7 +42,7 @@ class TestReleaseCLI(unittest.TestCase):
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
 
-        mock_prod_file = MagicMock(spec=file)
+        mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
                 'account_id': 987654321
@@ -116,7 +116,7 @@ class TestReleaseCLI(unittest.TestCase):
         self, check_call, check_output, mock_open,
         Session_from_config, Session_from_cli, mock_os
     ):
-        mock_metadata_file = MagicMock(spec=file)
+        mock_metadata_file = MagicMock(spec=TextIOWrapper)
         metadata = {
             'TEAM': 'dummy-team',
             'TYPE': 'docker',
@@ -125,7 +125,7 @@ class TestReleaseCLI(unittest.TestCase):
         }
         mock_metadata_file.read.return_value = json.dumps(metadata)
 
-        mock_dev_file = MagicMock(spec=file)
+        mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
                 'account_id': 123456789
@@ -133,7 +133,7 @@ class TestReleaseCLI(unittest.TestCase):
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
 
-        mock_prod_file = MagicMock(spec=file)
+        mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
                 'account_id': 987654321
@@ -225,7 +225,7 @@ class TestDeployCLI(unittest.TestCase):
         }
         mock_os_deploy.environ = {}
 
-        mock_metadata_file = MagicMock(spec=file)
+        mock_metadata_file = MagicMock(spec=TextIOWrapper)
         metadata = {
             'TEAM': 'dummy-team',
             'TYPE': 'docker',
@@ -234,7 +234,7 @@ class TestDeployCLI(unittest.TestCase):
         }
         mock_metadata_file.read.return_value = json.dumps(metadata)
 
-        mock_dev_file = MagicMock(spec=file)
+        mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
                 'account_id': 123456789
@@ -242,7 +242,7 @@ class TestDeployCLI(unittest.TestCase):
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
 
-        mock_prod_file = MagicMock(spec=file)
+        mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
                 'account_id': 987654321
@@ -470,7 +470,7 @@ class TestDestroyCLI(unittest.TestCase):
         }
         mock_os_deploy.environ = {}
 
-        mock_metadata_file = MagicMock(spec=file)
+        mock_metadata_file = MagicMock(spec=TextIOWrapper)
         metadata = {
             'TEAM': 'dummy-team',
             'TYPE': 'docker',
@@ -479,7 +479,7 @@ class TestDestroyCLI(unittest.TestCase):
         }
         mock_metadata_file.read.return_value = json.dumps(metadata)
 
-        mock_dev_file = MagicMock(spec=file)
+        mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
                 'account_id': 123456789
@@ -487,7 +487,7 @@ class TestDestroyCLI(unittest.TestCase):
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
 
-        mock_prod_file = MagicMock(spec=file)
+        mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
                 'account_id': 987654321

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -186,9 +186,9 @@ class TestReleaseCLI(unittest.TestCase):
         component_name = 'dummy-component'
         version = '1.2.3'
 
-        check_output.return_value = bytes('git@github.com:org/{}.git'.format(
+        check_output.return_value = 'git@github.com:org/{}.git'.format(
             component_name
-        ).encode('utf-8'))
+        ).encode('utf-8')
 
         cli.run(['release', version])
 
@@ -283,9 +283,9 @@ class TestDeployCLI(unittest.TestCase):
 
         component_name = 'dummy-component'
 
-        check_output.return_value = bytes('git@github.com:org/{}.git'.format(
+        check_output.return_value = 'git@github.com:org/{}.git'.format(
             component_name
-        ).encode('utf-8'))
+        ).encode('utf-8')
 
         cli.run(['deploy', 'aslive', '1.2.3'])
 
@@ -528,9 +528,9 @@ class TestDestroyCLI(unittest.TestCase):
 
         component_name = 'dummy-component'
 
-        check_output.return_value = bytes('git@github.com:org/{}.git'.format(
+        check_output.return_value = 'git@github.com:org/{}.git'.format(
             component_name
-        ).encode('utf-8'))
+        ).encode('utf-8')
 
         cli.run(['destroy', 'aslive'])
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -186,9 +186,9 @@ class TestReleaseCLI(unittest.TestCase):
         component_name = 'dummy-component'
         version = '1.2.3'
 
-        check_output.return_value = 'git@github.com:org/{}.git'.format(
+        check_output.return_value = bytes('git@github.com:org/{}.git'.format(
             component_name
-        )
+        ).encode('utf-8'))
 
         cli.run(['release', version])
 
@@ -283,9 +283,9 @@ class TestDeployCLI(unittest.TestCase):
 
         component_name = 'dummy-component'
 
-        check_output.return_value = 'git@github.com:org/{}.git'.format(
+        check_output.return_value = bytes('git@github.com:org/{}.git'.format(
             component_name
-        )
+        ).encode('utf-8'))
 
         cli.run(['deploy', 'aslive', '1.2.3'])
 
@@ -528,9 +528,9 @@ class TestDestroyCLI(unittest.TestCase):
 
         component_name = 'dummy-component'
 
-        check_output.return_value = 'git@github.com:org/{}.git'.format(
+        check_output.return_value = bytes('git@github.com:org/{}.git'.format(
             component_name
-        )
+        ).encode('utf-8'))
 
         cli.run(['destroy', 'aslive'])
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,8 +1,9 @@
 import unittest
 
 import json
+from io import TextIOWrapper
 from datetime import datetime
-from string import letters, digits, printable
+from string import ascii_letters, digits, printable
 
 from mock import patch, Mock, MagicMock, mock_open
 from hypothesis import example
@@ -12,7 +13,7 @@ from hypothesis.strategies import text, composite, fixed_dictionaries
 from cdflow_commands import config
 
 
-ROLE_SAFE_ALPHABET = letters + digits + '+=,.@-'
+ROLE_SAFE_ALPHABET = ascii_letters + digits + '+=,.@-'
 ROLE_UNSAFE_CHARACTERS = '\/!$%^&*()#'
 ROLE_UNSAFE_ALPHABET = ROLE_SAFE_ALPHABET + ROLE_UNSAFE_CHARACTERS
 
@@ -32,12 +33,12 @@ def email(draw, min_size=7):
         max_size=user_min_characters + 40
     ))
     domain = draw(text(
-        alphabet=letters + digits + '-',
+        alphabet=ascii_letters + digits + '-',
         min_size=domain_min_characters,
         max_size=domain_min_characters + 20
     ))
     tld = draw(text(
-        alphabet=letters,
+        alphabet=ascii_letters,
         min_size=tld_min_characters,
         max_size=tld_min_characters + 5
     ))
@@ -48,7 +49,7 @@ class TestLoadConfig(unittest.TestCase):
 
     @patch('cdflow_commands.config.open', new_callable=mock_open, create=True)
     def test_service_metadata_loaded(self, mock_open):
-        mock_file = MagicMock(spec=file)
+        mock_file = MagicMock(spec=TextIOWrapper)
         expected_config = {
             'TEAM': 'dummy-team',
             'TYPE': 'docker',
@@ -66,7 +67,7 @@ class TestLoadConfig(unittest.TestCase):
 
     @patch('cdflow_commands.config.open', new_callable=mock_open, create=True)
     def test_loaded_from_file(self, mock_open):
-        mock_dev_file = MagicMock(spec=file)
+        mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
                 'account_id': 123456789
@@ -74,7 +75,7 @@ class TestLoadConfig(unittest.TestCase):
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
 
-        mock_prod_file = MagicMock(spec=file)
+        mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
                 'account_id': 987654321
@@ -213,7 +214,7 @@ class TestGetRoleSessionName(unittest.TestCase):
 
         assert len(role_session_name) <= 64
 
-    @given(text(alphabet=letters))
+    @given(text(alphabet=ascii_letters))
     @example(r'Abc.example.com')
     @example(r'john.doe@example..com')
     def test_invalid_email_address(self, email):
@@ -240,7 +241,9 @@ class TestGetComponentName(unittest.TestCase):
         component_name = config.get_component_name('dummy-name')
         assert component_name == 'dummy-name'
 
-    @given(text(alphabet=letters + digits + '-._', min_size=1, max_size=100))
+    @given(text(
+        alphabet=ascii_letters + digits + '-._', min_size=1, max_size=100
+    ))
     def test_component_not_passed_as_argument(self, component_name):
         with patch('cdflow_commands.config.check_output') as check_output:
             check_output.return_value = 'git@github.com:org/{}.git\n'.format(
@@ -250,7 +253,9 @@ class TestGetComponentName(unittest.TestCase):
 
             assert extraced_component_name == component_name
 
-    @given(text(alphabet=letters + digits + '-._', min_size=1, max_size=100))
+    @given(text(
+        alphabet=ascii_letters + digits + '-._', min_size=1, max_size=100
+    ))
     def test_component_not_passed_as_argument_without_extension(
         self, component_name
     ):
@@ -262,7 +267,9 @@ class TestGetComponentName(unittest.TestCase):
 
             assert extraced_component_name == component_name
 
-    @given(text(alphabet=letters + digits + '-._', min_size=1, max_size=100))
+    @given(text(
+        alphabet=ascii_letters + digits + '-._', min_size=1, max_size=100
+    ))
     def test_component_not_passed_as_argument_with_https_origin(
         self, component_name
     ):
@@ -275,7 +282,9 @@ class TestGetComponentName(unittest.TestCase):
 
             assert extraced_component_name == component_name
 
-    @given(text(alphabet=letters + digits + '-._', min_size=1, max_size=100))
+    @given(text(
+        alphabet=ascii_letters + digits + '-._', min_size=1, max_size=100
+    ))
     def test_component_not_passed_as_argument_with_https_without_extension(
         self, component_name
     ):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -246,11 +246,9 @@ class TestGetComponentName(unittest.TestCase):
     ))
     def test_component_not_passed_as_argument(self, component_name):
         with patch('cdflow_commands.config.check_output') as check_output:
-            check_output.return_value = bytes(
-                'git@github.com:org/{}.git\n'.format(
-                    component_name
-                ).encode('utf-8')
-            )
+            check_output.return_value = 'git@github.com:org/{}.git\n'.format(
+                component_name
+            ).encode('utf-8')
             extraced_component_name = config.get_component_name(None)
 
             assert extraced_component_name == component_name
@@ -262,11 +260,9 @@ class TestGetComponentName(unittest.TestCase):
         self, component_name
     ):
         with patch('cdflow_commands.config.check_output') as check_output:
-            check_output.return_value = bytes(
-                'git@github.com:org/{}\n'.format(
-                    component_name
-                ).encode('utf-8')
-            )
+            check_output.return_value = 'git@github.com:org/{}\n'.format(
+                component_name
+            ).encode('utf-8')
             extraced_component_name = config.get_component_name(None)
 
             assert extraced_component_name == component_name
@@ -279,9 +275,9 @@ class TestGetComponentName(unittest.TestCase):
     ):
         with patch('cdflow_commands.config.check_output') as check_output:
             repo_template = 'https://github.com/org/{}.git\n'
-            check_output.return_value = bytes(
-                repo_template.format(component_name).encode('utf-8')
-            )
+            check_output.return_value = repo_template.format(
+                component_name
+            ).encode('utf-8')
             extraced_component_name = config.get_component_name(None)
 
             assert extraced_component_name == component_name
@@ -293,11 +289,9 @@ class TestGetComponentName(unittest.TestCase):
         self, component_name
     ):
         with patch('cdflow_commands.config.check_output') as check_output:
-            check_output.return_value = bytes(
-                'https://github.com/org/{}\n'.format(
-                    component_name
-                ).encode('utf-8')
-            )
+            check_output.return_value = 'https://github.com/org/{}\n'.format(
+                component_name
+            ).encode('utf-8')
             extraced_component_name = config.get_component_name(None)
 
             assert extraced_component_name == component_name

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -246,8 +246,10 @@ class TestGetComponentName(unittest.TestCase):
     ))
     def test_component_not_passed_as_argument(self, component_name):
         with patch('cdflow_commands.config.check_output') as check_output:
-            check_output.return_value = 'git@github.com:org/{}.git\n'.format(
-                component_name
+            check_output.return_value = bytes(
+                'git@github.com:org/{}.git\n'.format(
+                    component_name
+                ).encode('utf-8')
             )
             extraced_component_name = config.get_component_name(None)
 
@@ -260,8 +262,10 @@ class TestGetComponentName(unittest.TestCase):
         self, component_name
     ):
         with patch('cdflow_commands.config.check_output') as check_output:
-            check_output.return_value = 'git@github.com:org/{}\n'.format(
-                component_name
+            check_output.return_value = bytes(
+                'git@github.com:org/{}\n'.format(
+                    component_name
+                ).encode('utf-8')
             )
             extraced_component_name = config.get_component_name(None)
 
@@ -275,8 +279,8 @@ class TestGetComponentName(unittest.TestCase):
     ):
         with patch('cdflow_commands.config.check_output') as check_output:
             repo_template = 'https://github.com/org/{}.git\n'
-            check_output.return_value = repo_template.format(
-                component_name
+            check_output.return_value = bytes(
+                repo_template.format(component_name).encode('utf-8')
             )
             extraced_component_name = config.get_component_name(None)
 
@@ -289,8 +293,10 @@ class TestGetComponentName(unittest.TestCase):
         self, component_name
     ):
         with patch('cdflow_commands.config.check_output') as check_output:
-            check_output.return_value = 'https://github.com/org/{}\n'.format(
-                component_name
+            check_output.return_value = bytes(
+                'https://github.com/org/{}\n'.format(
+                    component_name
+                ).encode('utf-8')
             )
             extraced_component_name = config.get_component_name(None)
 

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -126,11 +126,12 @@ class TestDeploy(unittest.TestCase):
                 'cdflow_commands.deploy.check_call') as check_call:
 
             mock_os.environ = mock_environment.copy()
-            expected_environment = dict(mock_environment.items() + {
+            aws_env_vars = {
                 'AWS_ACCESS_KEY_ID': 'dummy-access_key_id',
                 'AWS_SECRET_ACCESS_KEY': 'dummy-secret_access_key',
                 'AWS_SESSION_TOKEN': 'dummy-session_token'
-            }.items())
+            }
+            expected_environment = {**mock_environment, **aws_env_vars}
 
             # When
             deploy.run()

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -1,6 +1,6 @@
 import unittest
 
-from string import uppercase, lowercase, digits
+from string import ascii_lowercase, ascii_letters, digits
 from base64 import b64encode
 import json
 
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError
 from cdflow_commands.release import Release, ReleaseConfig
 
 
-IDENTIFIER_ALPHABET = uppercase + lowercase + digits + '-_'
+IDENTIFIER_ALPHABET = ascii_letters + digits + '-_'
 
 
 class TestRelease(unittest.TestCase):
@@ -24,13 +24,15 @@ class TestRelease(unittest.TestCase):
                 {
                     'authorizationToken': b64encode('{}:{}'.format(
                         'dummy-username', 'dummy-password'
-                    )),
+                    ).encode('utf-8')),
                     'proxyEndpoint': 'dummy-proxy-endpoint'
                 }
             ]
         }
 
-    @given(text(alphabet=lowercase + digits + '-', min_size=1, max_size=10))
+    @given(text(
+        alphabet=ascii_lowercase + digits + '-', min_size=1, max_size=10
+    ))
     @given(text(alphabet=digits, min_size=12, max_size=12))
     @given(text(alphabet=IDENTIFIER_ALPHABET, min_size=1, max_size=10))
     @settings(max_examples=10)
@@ -97,7 +99,7 @@ class TestRelease(unittest.TestCase):
                 {
                     'authorizationToken': b64encode('{}:{}'.format(
                         username, password
-                    )),
+                    ).encode('utf-8')),
                     'proxyEndpoint': proxy_endpoint
                 }
             ]
@@ -143,7 +145,7 @@ class TestRelease(unittest.TestCase):
                 {
                     'authorizationToken': b64encode('{}:{}'.format(
                         'dummy-username', 'dummy-password'
-                    )),
+                    ).encode('utf-8')),
                     'proxyEndpoint': 'dummy-proxy-endpoint'
                 }
             ]
@@ -165,7 +167,7 @@ class TestRelease(unittest.TestCase):
                 repositoryName=component_name
             )
 
-    @given(text(alphabet=lowercase + uppercase, min_size=8, max_size=16))
+    @given(text(alphabet=ascii_letters, min_size=8, max_size=16))
     def test_exception_re_raised(self, error_code):
         assume(error_code != 'RepositoryNotFoundException')
 
@@ -180,7 +182,7 @@ class TestRelease(unittest.TestCase):
                 {
                     'authorizationToken': b64encode('{}:{}'.format(
                         'dummy-username', 'dummy-password'
-                    )),
+                    ).encode('utf-8')),
                     'proxyEndpoint': 'dummy-proxy-endpoint'
                 }
             ]
@@ -212,7 +214,7 @@ class TestRelease(unittest.TestCase):
                 {
                     'authorizationToken': b64encode('{}:{}'.format(
                         'dummy-username', 'dummy-password'
-                    )),
+                    ).encode('utf-8')),
                     'proxyEndpoint': 'dummy-proxy-endpoint'
                 }
             ]


### PR DESCRIPTION
We're currently running Python 2 but that's end-of-life in 2020 so let's get the drop on that and move to Python 3 while we still have the chance.