### PR TITLE
Simplify terraform detstroy

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -26,7 +26,7 @@ from cdflow_commands.config import (
 )
 from cdflow_commands.release import Release, ReleaseConfig
 from cdflow_commands.deploy import Deploy, DeployConfig
-from cdflow_commands.destroy import Destroy, DestroyConfig
+from cdflow_commands.destroy import Destroy
 from cdflow_commands.terragrunt import S3BucketFactory, write_terragrunt_config
 
 
@@ -87,13 +87,7 @@ def _run_infrastructure_commmand(
             global_config.dev_account_id
         )
     elif args['destroy']:
-        _run_destroy(
-            metadata.team,
-            platform_config_file,
-            boto_session,
-            component_name,
-            environment_name
-        )
+        _run_destroy(boto_session, component_name, environment_name)
 
 
 def _setup_for_infrastructure(
@@ -137,14 +131,6 @@ def _run_deploy(
     deployment.run()
 
 
-def _run_destroy(
-    team, platform_config_file, boto_session, component_name, environment_name
-):
-    destroy_config = DestroyConfig(
-        team=team,
-        platform_config_file=platform_config_file,
-    )
-    destroyment = Destroy(
-        boto_session, component_name, environment_name, destroy_config
-    )
+def _run_destroy(boto_session, component_name, environment_name):
+    destroyment = Destroy(boto_session, component_name, environment_name)
     destroyment.run()

--- a/cdflow_commands/deploy.py
+++ b/cdflow_commands/deploy.py
@@ -1,8 +1,7 @@
 from subprocess import check_call
 from collections import namedtuple
 import os
-
-from cdflow_commands.terragrunt import build_command_parameters
+from os import path
 
 
 DeployConfig = namedtuple('DeployConfig', [
@@ -38,15 +37,19 @@ class Deploy(object):
 
     @property
     def _terragrunt_parameters(self):
-        return build_command_parameters(
-            self._component_name,
-            self._environment_name,
-            self._aws_region,
-            self._team,
-            self._image_name,
-            self._version,
-            self._platform_config_file,
-        )
+        parameters = [
+            '-var', 'component={}'.format(self._component_name),
+            '-var', 'env={}'.format(self._environment_name),
+            '-var', 'aws_region={}'.format(self._aws_region),
+            '-var', 'team={}'.format(self._team),
+            '-var', 'image={}'.format(self._image_name),
+            '-var', 'version={}'.format(self._version),
+            '-var-file', self._platform_config_file,
+        ]
+        config_file = 'config/{}.json'.format(self._environment_name)
+        if path.exists(config_file):
+            parameters += ['-var-file', config_file]
+        return parameters + ['infra']
 
     def run(self):
         check_call(['terragrunt', 'get', 'infra'])

--- a/cdflow_commands/destroy.py
+++ b/cdflow_commands/destroy.py
@@ -1,39 +1,23 @@
 import os
 from subprocess import check_call
-from collections import namedtuple
-
-from cdflow_commands.terragrunt import build_command_parameters
-
-
-DestroyConfig = namedtuple('DestroyConfig', [
-    'team', 'platform_config_file'
-])
 
 
 class Destroy(object):
 
-    def __init__(self, boto_session, component_name, environment_name, config):
+    def __init__(self, boto_session, component_name, environment_name):
         self._boto_session = boto_session
         self._aws_region = boto_session.region_name
         self._component_name = component_name
         self._environment_name = environment_name
-        self._team = config.team
-        self._platform_config_file = config.platform_config_file
 
     @property
     def _terragrunt_parameters(self):
-        return build_command_parameters(
-            self._component_name,
-            self._environment_name,
-            self._aws_region,
-            self._team,
-            'any',
-            'all',
-            self._platform_config_file,
-        )
+        return [
+            '-var', 'aws_region={}'.format(self._aws_region),
+            '/cdflow/tf-destroy'
+        ]
 
     def run(self):
-        check_call(['terragrunt', 'get', 'infra'])
         credentials = self._boto_session.get_credentials()
         aws_credentials = {
             'AWS_ACCESS_KEY_ID': credentials.access_key,
@@ -43,7 +27,7 @@ class Destroy(object):
         env = os.environ.copy()
         env.update(aws_credentials)
         check_call(
-            ['terragrunt', 'plan'] + self._terragrunt_parameters,
+            ['terragrunt', 'plan', '-destroy'] + self._terragrunt_parameters,
             env=env
         )
         check_call(

--- a/cdflow_commands/terragrunt.py
+++ b/cdflow_commands/terragrunt.py
@@ -1,6 +1,5 @@
 from hashlib import sha1
 from textwrap import dedent
-from os import path
 
 from botocore.exceptions import ClientError
 
@@ -145,27 +144,3 @@ def write_terragrunt_config(
     )
     with open('.terragrunt', 'w') as f:
         f.write(config)
-
-
-def build_command_parameters(
-    component_name,
-    environment_name,
-    aws_region,
-    team,
-    image,
-    version,
-    platform_config_file
-):
-    parameters = [
-        '-var', 'component={}'.format(component_name),
-        '-var', 'env={}'.format(environment_name),
-        '-var', 'aws_region={}'.format(aws_region),
-        '-var', 'team={}'.format(team),
-        '-var', 'image={}'.format(image),
-        '-var', 'version={}'.format(version),
-        '-var-file', platform_config_file,
-    ]
-    config_file = 'config/{}.json'.format(environment_name)
-    if path.exists(config_file):
-        parameters += ['-var-file', config_file]
-    return parameters + ['infra']

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -534,19 +534,11 @@ class TestDestroyCLI(unittest.TestCase):
 
         cli.run(['destroy', 'aslive'])
 
-        check_call.assert_any_call(['terragrunt', 'get', 'infra'])
-
         check_call.assert_any_call(
             [
-                'terragrunt', 'plan',
-                '-var', 'component=dummy-component',
-                '-var', 'env=aslive',
+                'terragrunt', 'plan', '-destroy',
                 '-var', 'aws_region=eu-west-12',
-                '-var', 'team=dummy-team',
-                '-var', 'image=any',
-                '-var', 'version=all',
-                '-var-file', 'infra/platform-config/mmg/dev/eu-west-12.json',
-                'infra'
+                '/cdflow/tf-destroy'
             ],
             env={
                 'AWS_ACCESS_KEY_ID': aws_access_key_id,
@@ -558,14 +550,8 @@ class TestDestroyCLI(unittest.TestCase):
         check_call.assert_any_call(
             [
                 'terragrunt', 'destroy', '-force',
-                '-var', 'component=dummy-component',
-                '-var', 'env=aslive',
                 '-var', 'aws_region=eu-west-12',
-                '-var', 'team=dummy-team',
-                '-var', 'image=any',
-                '-var', 'version=all',
-                '-var-file', 'infra/platform-config/mmg/dev/eu-west-12.json',
-                'infra'
+                '/cdflow/tf-destroy'
             ],
             env={
                 'AWS_ACCESS_KEY_ID': aws_access_key_id,

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import patch
-from string import printable
+from string import printable, ascii_letters
 
 from hypothesis import given
 from hypothesis.strategies import text, fixed_dictionaries, dictionaries
@@ -239,7 +239,7 @@ class TestDeploy(unittest.TestCase):
 
 class TestEnvironmentSpecificConfigAddedToTerraformArgs(unittest.TestCase):
 
-    @given(text())
+    @given(text(alphabet=ascii_letters, min_size=2, max_size=10))
     def test_environment_specific_config_in_args(self, env_name):
 
         # Given
@@ -259,7 +259,7 @@ class TestEnvironmentSpecificConfigAddedToTerraformArgs(unittest.TestCase):
         with patch(
             'cdflow_commands.deploy.check_call'
         ) as check_call, patch(
-            'cdflow_commands.terragrunt.path'
+            'cdflow_commands.deploy.path'
         ) as path:
             path.exists.return_value = True
             deploy.run()

--- a/test/test_destroy.py
+++ b/test/test_destroy.py
@@ -2,13 +2,13 @@ import unittest
 
 from string import printable
 
-from mock import patch, Mock, ANY
+from mock import patch, ANY
 from hypothesis import given
 from hypothesis.strategies import text, dictionaries, fixed_dictionaries
 
 from boto3 import Session
 
-from cdflow_commands.destroy import Destroy, DestroyConfig
+from cdflow_commands.destroy import Destroy
 
 
 CALL_KWARGS = 2
@@ -16,88 +16,49 @@ CALL_KWARGS = 2
 
 class TestDestroy(unittest.TestCase):
 
-    def test_external_modules_are_imported(self):
-        config = DestroyConfig(
-            team='dummy-team',
-            platform_config_file='./dummy/file/path.json'
-        )
-        destroy = Destroy(
-            Mock(), 'dummy-component', 'dummy-environment', config
-        )
-
-        with patch('cdflow_commands.destroy.check_call') as check_call:
-            destroy.run()
-
-            check_call.assert_any_call(['terragrunt', 'get', 'infra'])
-
     @given(fixed_dictionaries({
         'component_name': text(alphabet=printable, min_size=1),
         'environment_name': text(alphabet=printable, min_size=1),
+        'region': text(alphabet=printable, min_size=8, max_size=12),
     }))
     def test_plan_was_called_via_terragrunt(self, test_fixtures):
         component_name = test_fixtures['component_name']
         environment_name = test_fixtures['environment_name']
-        config = DestroyConfig(
-            team='dummy-team',
-            platform_config_file='./dummy/file/path.json'
-        )
-        boto_session = Session('ANY', 'ANY', 'ANY', 'dummy-region')
+        boto_session = Session('ANY', 'ANY', 'ANY', test_fixtures['region'])
         destroy = Destroy(
-            boto_session, component_name, environment_name, config
+            boto_session, component_name, environment_name
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
             destroy.run()
 
-            check_call.assert_any_call(
-                [
-                    'terragrunt', 'plan',
-                    '-var', 'component={}'.format(component_name),
-                    '-var', 'env={}'.format(environment_name),
-                    '-var', 'aws_region=dummy-region',
-                    '-var', 'team=dummy-team',
-                    '-var', 'image=any',
-                    '-var', 'version=all',
-                    '-var-file', './dummy/file/path.json',
-                    'infra',
-                ],
-                env=ANY
-            )
+            check_call.assert_any_call([
+                'terragrunt', 'plan', '-destroy',
+                '-var', 'aws_region={}'.format(test_fixtures['region']),
+                '/cdflow/tf-destroy'
+            ], env=ANY)
 
     @given(fixed_dictionaries({
         'component_name': text(alphabet=printable, min_size=1),
         'environment_name': text(alphabet=printable, min_size=1),
+        'region': text(alphabet=printable, min_size=8, max_size=12),
     }))
     def test_destroy_was_called_via_terragrunt(self, test_fixtures):
         component_name = test_fixtures['component_name']
         environment_name = test_fixtures['environment_name']
-        config = DestroyConfig(
-            team='dummy-team',
-            platform_config_file='./dummy/file/path.json'
-        )
-        boto_session = Session('ANY', 'ANY', 'ANY', 'dummy-region')
+        boto_session = Session('ANY', 'ANY', 'ANY', test_fixtures['region'])
         destroy = Destroy(
-            boto_session, component_name, environment_name, config
+            boto_session, component_name, environment_name
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
             destroy.run()
 
-            check_call.assert_any_call(
-                [
-                    'terragrunt', 'destroy',
-                    '-force',
-                    '-var', 'component={}'.format(component_name),
-                    '-var', 'env={}'.format(environment_name),
-                    '-var', 'aws_region=dummy-region',
-                    '-var', 'team=dummy-team',
-                    '-var', 'image=any',
-                    '-var', 'version=all',
-                    '-var-file', './dummy/file/path.json',
-                    'infra',
-                ],
-                env=ANY
-            )
+            check_call.assert_any_call([
+                'terragrunt', 'destroy', '-force',
+                '-var', 'aws_region={}'.format(test_fixtures['region']),
+                '/cdflow/tf-destroy'
+            ], env=ANY)
 
     @given(fixed_dictionaries({
         'access_key': text(alphabet=printable, min_size=1),
@@ -105,10 +66,6 @@ class TestDestroy(unittest.TestCase):
         'session_token': text(alphabet=printable, min_size=1),
     }))
     def test_aws_config_was_passed_into_envionrment(self, aws_config):
-        config = DestroyConfig(
-            team='dummy-team',
-            platform_config_file='./dummy/file/path.json'
-        )
         boto_session = Session(
             aws_config['access_key'],
             aws_config['secret_key'],
@@ -116,18 +73,18 @@ class TestDestroy(unittest.TestCase):
             'dummy-region'
         )
         destroy = Destroy(
-            boto_session, 'dummy-component', 'dummy-environment', config
+            boto_session, 'dummy-component', 'dummy-environment'
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
             destroy.run()
 
-            env = check_call.mock_calls[1][CALL_KWARGS]['env']
+            env = check_call.mock_calls[0][CALL_KWARGS]['env']
             assert env['AWS_ACCESS_KEY_ID'] == aws_config['access_key']
             assert env['AWS_SECRET_ACCESS_KEY'] == aws_config['secret_key']
             assert env['AWS_SESSION_TOKEN'] == aws_config['session_token']
 
-            env = check_call.mock_calls[2][CALL_KWARGS]['env']
+            env = check_call.mock_calls[1][CALL_KWARGS]['env']
             assert env['AWS_ACCESS_KEY_ID'] == aws_config['access_key']
             assert env['AWS_SECRET_ACCESS_KEY'] == aws_config['secret_key']
             assert env['AWS_SESSION_TOKEN'] == aws_config['session_token']
@@ -138,10 +95,6 @@ class TestDestroy(unittest.TestCase):
         min_size=1
     ))
     def test_original_environment_was_preserved(self, mock_env):
-        config = DestroyConfig(
-            team='dummy-team',
-            platform_config_file='./dummy/file/path.json'
-        )
         boto_session = Session(
             'dummy-access-key',
             'dummy-secret-key',
@@ -149,7 +102,7 @@ class TestDestroy(unittest.TestCase):
             'dummy-region'
         )
         destroy = Destroy(
-            boto_session, 'dummy-component', 'dummy-environment', config
+            boto_session, 'dummy-component', 'dummy-environment'
         )
 
         with patch(
@@ -160,10 +113,10 @@ class TestDestroy(unittest.TestCase):
             mock_os.environ = mock_env.copy()
             destroy.run()
 
-            env = check_call.mock_calls[1][CALL_KWARGS]['env']
+            env = check_call.mock_calls[0][CALL_KWARGS]['env']
             for key, value in mock_env.items():
                 assert env[key] == value
 
-            env = check_call.mock_calls[2][CALL_KWARGS]['env']
+            env = check_call.mock_calls[1][CALL_KWARGS]['env']
             for key, value in mock_env.items():
                 assert env[key] == value

--- a/tf-destroy/main.tf
+++ b/tf-destroy/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+variable "aws_region" {
+  description = "The AWS region to destroy resources in."
+}
+


### PR DESCRIPTION
The only things that are needed (and should be needed) for a destroy
are the tfstate file and the AWS region. This change refactors destroy
to just use those.

JIRA: PLAT-820