### PR TITLE
Remove tfstate file from s3 after destroy

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -82,7 +82,7 @@ def _run_infrastructure_commmand(
     args, metadata, global_config, root_session, component_name
 ):
     environment_name = args['<environment>']
-    boto_session, platform_config_file = _setup_for_infrastructure(
+    boto_session, platform_config_file, s3_bucket = _setup_for_infrastructure(
         environment_name, component_name, metadata, global_config, root_session
     )
     if args['deploy']:
@@ -96,7 +96,7 @@ def _run_infrastructure_commmand(
             global_config.dev_account_id
         )
     elif args['destroy']:
-        _run_destroy(boto_session, component_name, environment_name)
+        _run_destroy(boto_session, component_name, environment_name, s3_bucket)
 
 
 def _setup_for_infrastructure(
@@ -121,7 +121,7 @@ def _setup_for_infrastructure(
     write_terragrunt_config(
         metadata.aws_region, s3_bucket, environment_name, component_name
     )
-    return boto_session, platform_config_file
+    return boto_session, platform_config_file, s3_bucket
 
 
 def _run_deploy(
@@ -140,6 +140,8 @@ def _run_deploy(
     deployment.run()
 
 
-def _run_destroy(boto_session, component_name, environment_name):
-    destroyment = Destroy(boto_session, component_name, environment_name)
+def _run_destroy(boto_session, component_name, environment_name, s3_bucket):
+    destroyment = Destroy(
+        boto_session, component_name, environment_name, s3_bucket
+    )
     destroyment.run()

--- a/cdflow_commands/destroy.py
+++ b/cdflow_commands/destroy.py
@@ -40,7 +40,7 @@ class Destroy(object):
         boto_s3_client = self._boto_session.client('s3')
         boto_s3_client.delete_object(
             Bucket=self._bucket_name,
-            Key='{}/{}/tfstate.json'.format(
+            Key='{}/{}/terraform.tfstate'.format(
                 self._environment_name, self._component_name
             )
         )

--- a/cdflow_commands/destroy.py
+++ b/cdflow_commands/destroy.py
@@ -4,11 +4,14 @@ from subprocess import check_call
 
 class Destroy(object):
 
-    def __init__(self, boto_session, component_name, environment_name):
+    def __init__(
+        self, boto_session, component_name, environment_name, bucket_name
+    ):
         self._boto_session = boto_session
         self._aws_region = boto_session.region_name
         self._component_name = component_name
         self._environment_name = environment_name
+        self._bucket_name = bucket_name
 
     @property
     def _terragrunt_parameters(self):
@@ -33,4 +36,11 @@ class Destroy(object):
         check_call(
             ['terragrunt', 'destroy', '-force'] + self._terragrunt_parameters,
             env=env
+        )
+        boto_s3_client = self._boto_session.client('s3')
+        boto_s3_client.delete_object(
+            Bucket=self._bucket_name,
+            Key='{}/{}/tfstate.json'.format(
+                self._environment_name, self._component_name
+            )
         )

--- a/test/test_destroy.py
+++ b/test/test_destroy.py
@@ -1,15 +1,15 @@
 import unittest
 
 from string import printable
+from collections import namedtuple
 
-from mock import patch, ANY
+from mock import patch, ANY, Mock
 from hypothesis import given
 from hypothesis.strategies import text, dictionaries, fixed_dictionaries
 
-from boto3 import Session
-
 from cdflow_commands.destroy import Destroy
 
+BotoCreds = namedtuple('BotoCreds', ['access_key', 'secret_key', 'token'])
 
 CALL_KWARGS = 2
 
@@ -24,9 +24,11 @@ class TestDestroy(unittest.TestCase):
     def test_plan_was_called_via_terragrunt(self, test_fixtures):
         component_name = test_fixtures['component_name']
         environment_name = test_fixtures['environment_name']
-        boto_session = Session('ANY', 'ANY', 'ANY', test_fixtures['region'])
+
+        boto_session = Mock()
+        boto_session.region_name = test_fixtures['region']
         destroy = Destroy(
-            boto_session, component_name, environment_name
+            boto_session, component_name, environment_name, 'dummy-bucket'
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
@@ -45,9 +47,10 @@ class TestDestroy(unittest.TestCase):
     def test_destroy_was_called_via_terragrunt(self, test_fixtures):
         component_name = test_fixtures['component_name']
         environment_name = test_fixtures['environment_name']
-        boto_session = Session('ANY', 'ANY', 'ANY', test_fixtures['region'])
+        boto_session = Mock()
+        boto_session.region_name = test_fixtures['region']
         destroy = Destroy(
-            boto_session, component_name, environment_name
+            boto_session, component_name, environment_name, 'dummy-bucket'
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
@@ -64,14 +67,16 @@ class TestDestroy(unittest.TestCase):
         'session_token': text(alphabet=printable, min_size=1),
     }))
     def test_aws_config_was_passed_into_envionrment(self, aws_config):
-        boto_session = Session(
+        boto_session = Mock()
+        boto_session.region_name = 'dummy-region'
+        boto_session.get_credentials.return_value = BotoCreds(
             aws_config['access_key'],
             aws_config['secret_key'],
             aws_config['session_token'],
-            'dummy-region'
         )
         destroy = Destroy(
-            boto_session, 'dummy-component', 'dummy-environment'
+            boto_session, 'dummy-component',
+            'dummy-environment', 'dummy-bucket'
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
@@ -93,14 +98,16 @@ class TestDestroy(unittest.TestCase):
         min_size=1
     ))
     def test_original_environment_was_preserved(self, mock_env):
-        boto_session = Session(
+        boto_session = Mock()
+        boto_session.region_name = 'dummy-region'
+        boto_session.get_credentials.return_value = BotoCreds(
             'dummy-access-key',
             'dummy-secret-key',
             'dummy-session-token',
-            'dummy-region'
         )
         destroy = Destroy(
-            boto_session, 'dummy-component', 'dummy-environment'
+            boto_session, 'dummy-component',
+            'dummy-environment', 'dummy-bucket'
         )
 
         with patch(
@@ -118,3 +125,39 @@ class TestDestroy(unittest.TestCase):
             env = check_call.mock_calls[1][CALL_KWARGS]['env']
             for key, value in mock_env.items():
                 assert env[key] == value
+
+    @given(fixed_dictionaries({
+        'component_name': text(alphabet=printable, min_size=1),
+        'environment_name': text(alphabet=printable, min_size=1),
+        's3_bucket_name': text(alphabet=printable, min_size=1),
+    }))
+    def test_tfstate_removed_from_s3(self, test_fixtures):
+        # Given
+        boto_session = Mock()
+        boto_session.region_name = 'dummy-region'
+        boto_session.get_credentials.return_value = BotoCreds(
+            'dummy-access-key',
+            'dummy-secret-key',
+            'dummy-session-token',
+        )
+        boto_s3_client = Mock()
+        boto_session.client.return_value = boto_s3_client
+        destroy = Destroy(
+            boto_session,
+            test_fixtures['component_name'],
+            test_fixtures['environment_name'],
+            test_fixtures['s3_bucket_name']
+        )
+
+        # When
+        with patch('cdflow_commands.destroy.check_call'):
+            destroy.run()
+
+        # Then
+        boto_s3_client.delete_object.assert_any_call(
+            Bucket=test_fixtures['s3_bucket_name'],
+            Key='{}/{}/tfstate.json'.format(
+                test_fixtures['environment_name'],
+                test_fixtures['component_name']
+            )
+        )

--- a/test/test_destroy.py
+++ b/test/test_destroy.py
@@ -156,7 +156,7 @@ class TestDestroy(unittest.TestCase):
         # Then
         boto_s3_client.delete_object.assert_any_call(
             Bucket=test_fixtures['s3_bucket_name'],
-            Key='{}/{}/tfstate.json'.format(
+            Key='{}/{}/terraform.tfstate'.format(
                 test_fixtures['environment_name'],
                 test_fixtures['component_name']
             )


### PR DESCRIPTION
So that we don't think a service exists because the (empty) tfstate
file is hanging around.

JIRA: PLAT-820