### PR TITLE
PLAT-803 - monitor ecs deployment

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -23,14 +23,14 @@ from cdflow_commands.config import (
     get_role_session_name,
     assume_role,
     get_component_name,
-    get_platform_config_path,
-    UserError
+    get_platform_config_path
 )
 from cdflow_commands.release import Release, ReleaseConfig
 from cdflow_commands.deploy import Deploy, DeployConfig
 from cdflow_commands.destroy import Destroy
 from cdflow_commands.terragrunt import S3BucketFactory, write_terragrunt_config
 from cdflow_commands.ecs_monitor import ECSEventIterator, ECSMonitor
+from cdflow_commands.exceptions import UserError
 
 
 def run(argv):

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -94,6 +94,7 @@ def _run_infrastructure_commmand(
             component_name,
             environment_name,
             args['<version>'],
+            metadata.ecs_cluster,
             global_config
         )
     elif args['destroy']:
@@ -127,14 +128,8 @@ def _setup_for_infrastructure(
 
 def _run_deploy(
     team, platform_config_file, boto_session, component_name, environment_name,
-    version, global_config
+    version, ecs_cluster, global_config
 ):
-    is_prod = environment_name == 'live'
-    if is_prod:
-        cluster = global_config.prod_ecs_cluster
-    else:
-        cluster = global_config.dev_ecs_cluster
-
     deploy_config = DeployConfig(
         team=team,
         dev_account_id=global_config.dev_account_id,
@@ -142,11 +137,11 @@ def _run_deploy(
     )
     deployment = Deploy(
         boto_session, component_name, environment_name, version,
-        deploy_config
+        ecs_cluster, deploy_config
     )
     deployment.run()
     events = ECSEventIterator(
-        cluster, environment_name, component_name, version, boto_session
+        ecs_cluster, environment_name, component_name, version, boto_session
     )
     monitor = ECSMonitor(events)
     monitor.wait()

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -82,7 +82,7 @@ def _run_infrastructure_commmand(
     args, metadata, global_config, root_session, component_name
 ):
     environment_name = args['<environment>']
-    boto_session, platform_config_file = _setup_for_infrastructure(
+    boto_session, platform_config_file, s3_bucket = _setup_for_infrastructure(
         environment_name, component_name, metadata, global_config, root_session
     )
     if args['deploy']:
@@ -96,7 +96,7 @@ def _run_infrastructure_commmand(
             global_config.dev_account_id
         )
     elif args['destroy']:
-        _run_destroy(boto_session, component_name, environment_name)
+        _run_destroy(boto_session, component_name, environment_name, s3_bucket)
 
 
 def _setup_for_infrastructure(
@@ -121,7 +121,7 @@ def _setup_for_infrastructure(
     write_terragrunt_config(
         metadata.aws_region, s3_bucket, environment_name, component_name
     )
-    return boto_session, platform_config_file
+    return boto_session, platform_config_file, s3_bucket
 
 
 def _run_deploy(
@@ -140,6 +140,8 @@ def _run_deploy(
     deployment.run()
 
 
-def _run_destroy(boto_session, component_name, environment_name):
-    destroyment = Destroy(boto_session, component_name, environment_name)
+def _run_destroy(boto_session, component_name, environment_name, s3_bucket):
+    destroyment = Destroy(
+        boto_session, component_name, environment_name, s3_bucket
+    )
     destroyment.run()

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -33,7 +33,7 @@ class NoGitRemoteError(UserError):
 
 
 Metadata = namedtuple(
-    'Metadata', ['team', 'type', 'aws_region', 'account_prefix']
+    'Metadata', ['team', 'type', 'aws_region', 'account_prefix', 'ecs_cluster']
 )
 
 
@@ -54,7 +54,8 @@ def load_service_metadata():
             metadata['TEAM'],
             metadata['TYPE'],
             metadata['REGION'],
-            metadata['ACCOUNT_PREFIX']
+            metadata['ACCOUNT_PREFIX'],
+            metadata.get('ECS_CLUSTER', 'default')
         )
 
 
@@ -125,7 +126,7 @@ def get_component_name(component_name):
 def _get_component_name_from_git_remote():
     try:
         remote = check_output(['git', 'config', 'remote.origin.url'])
-    except CalledProcessError as e:
+    except CalledProcessError:
         raise NoGitRemoteError()
     name = remote.decode('utf-8').strip().split('/')[-1]
     if name.endswith('.git'):

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -38,7 +38,12 @@ Metadata = namedtuple(
 
 
 GlobalConfig = namedtuple(
-    'GlobalConfig', ['dev_account_id', 'prod_account_id']
+    'GlobalConfig', [
+        'dev_account_id',
+        'prod_account_id',
+        'dev_ecs_cluster',
+        'prod_ecs_cluster'
+    ]
 )
 
 
@@ -54,17 +59,25 @@ def load_service_metadata():
 
 
 def load_global_config(account_prefix, aws_region):
+    ecs_cluster = 'default'
+    ecs_cluster_key = 'ecs_cluster.{}.name'.format(ecs_cluster)
     with open(get_platform_config_path(
         account_prefix, aws_region, is_prod=False
     )) as f:
-        dev_account_id = json.loads(f.read())['platform_config']['account_id']
+        config = json.loads(f.read())
+        dev_account_id = config['platform_config']['account_id']
+        dev_ecs_cluster = config['platform_config'][ecs_cluster_key]
 
     with open(get_platform_config_path(
         account_prefix, aws_region, is_prod=True
     )) as f:
-        prod_account_id = json.loads(f.read())['platform_config']['account_id']
+        config = json.loads(f.read())
+        prod_account_id = config['platform_config']['account_id']
+        prod_ecs_cluster = config['platform_config'][ecs_cluster_key]
 
-    return GlobalConfig(dev_account_id, prod_account_id)
+    return GlobalConfig(
+        dev_account_id, prod_account_id, dev_ecs_cluster, prod_ecs_cluster
+    )
 
 
 def assume_role(root_session, acccount_id, session_name):

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -5,15 +5,10 @@ from subprocess import check_output, CalledProcessError
 
 from boto3.session import Session
 
+from cdflow_commands.exceptions import UserError
+
 
 PLATFORM_CONFIG_PATH_TEMPLATE = 'infra/platform-config/{}/{}/{}.json'
-
-
-class UserError(Exception):
-    _message = 'User error'
-
-    def __str__(self):
-        return self._message
 
 
 class JobNameTooShortError(UserError):

--- a/cdflow_commands/deploy.py
+++ b/cdflow_commands/deploy.py
@@ -18,13 +18,14 @@ class Deploy(object):
 
     def __init__(
         self, boto_session, component_name, environment_name,
-        version, config
+        version, ecs_cluster, config
     ):
         self._boto_session = boto_session
         self._aws_region = boto_session.region_name
         self._component_name = component_name
         self._environment_name = environment_name
         self._version = version
+        self._ecs_cluster = ecs_cluster
         self._team = config.team
         self._dev_account_id = config.dev_account_id
         self._platform_config_file = config.platform_config_file
@@ -46,6 +47,7 @@ class Deploy(object):
             '-var', 'team={}'.format(self._team),
             '-var', 'image={}'.format(self._image_name),
             '-var', 'version={}'.format(self._version),
+            '-var', 'ecs_cluster={}'.format(self._ecs_cluster),
             '-var-file', self._platform_config_file,
             '-var-file', secrets_file
         ]

--- a/cdflow_commands/destroy.py
+++ b/cdflow_commands/destroy.py
@@ -40,7 +40,7 @@ class Destroy(object):
         boto_s3_client = self._boto_session.client('s3')
         boto_s3_client.delete_object(
             Bucket=self._bucket_name,
-            Key='{}/{}/tfstate.json'.format(
+            Key='{}/{}/terraform.tfstate'.format(
                 self._environment_name, self._component_name
             )
         )

--- a/cdflow_commands/destroy.py
+++ b/cdflow_commands/destroy.py
@@ -4,11 +4,14 @@ from subprocess import check_call
 
 class Destroy(object):
 
-    def __init__(self, boto_session, component_name, environment_name):
+    def __init__(
+        self, boto_session, component_name, environment_name, bucket_name
+    ):
         self._boto_session = boto_session
         self._aws_region = boto_session.region_name
         self._component_name = component_name
         self._environment_name = environment_name
+        self._bucket_name = bucket_name
 
     @property
     def _terragrunt_parameters(self):
@@ -33,4 +36,11 @@ class Destroy(object):
         check_call(
             ['terragrunt', 'destroy', '-force'] + self._terragrunt_parameters,
             env=env
+        )
+        boto_s3_client = self._boto_session.client('s3')
+        boto_s3_client.delete_object(
+            Bucket=self._bucket_name,
+            Key='{}/{}/tfstate.json'.format(
+                self._environment_name, self._component_name
+            )
         )

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -92,7 +92,7 @@ class ECSEventIterator():
             taskDefinition=task_definition_arn
         )['taskDefinition']['containerDefinitions'][0]
 
-        return task_def['image'].split('/')[1]
+        return task_def['image'].split('/', 1)[1]
 
     def _get_primary_deployment(self):
         services = self._ecs.describe_services(

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -75,20 +75,25 @@ class ECSEventIterator():
         ][0]
 
 
-class DoneEvent():
+class Event():
 
     def __init__(self, running, desired):
+        self.running = running
+        self.desired = desired
+
+
+class DoneEvent(Event):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.done = True
-        self.running = running
-        self.desired = desired
 
 
-class InProgressEvent():
+class InProgressEvent(Event):
 
-    def __init__(self, running, desired):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.done = False
-        self.running = running
-        self.desired = desired
 
 
 class TimeoutError(Exception):

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -30,11 +30,6 @@ class ECSMonitor():
         for event in self._ecs_event_iterator:
             if time() - start > TIMEOUT:
                 raise TimeoutError
-            if event.done:
-                logger.info('Deployment complete - running: {}'.format(
-                    event.running
-                ))
-                return True
             logger.info(
                 'Deploying ECS tasks - '
                 'desired: {} pending: {} running: {} previous: {}'.format(
@@ -42,6 +37,9 @@ class ECSMonitor():
                     event.running, event.previous_running
                 )
             )
+            if event.done:
+                logger.info('Deployment complete')
+                return True
 
             sleep(INTERVAL)
 

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -50,10 +50,9 @@ class ECSEventIterator():
         return build_service_name(self._environment, self._component)
 
     @property
+    @lru_cache(maxsize=1)
     def _ecs(self):
-        if not getattr(self, '_ecs_client', None):
-            self._ecs_client = self._boto_session.client('ecs')
-        return self._ecs_client
+        return self._boto_session.client('ecs')
 
     @lru_cache(maxsize=10)
     def _get_release_image(self, task_definition_arn):

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -28,16 +28,20 @@ class ECSMonitor():
         for event in self._ecs_event_iterator:
             if time() - start > self._TIMEOUT:
                 logger.error(
-                    'Deployment timed out! '
-                    'Didn\'t complete within {} seconds'.format(self._TIMEOUT)
+                    'Deployment timed out - '
+                    'didn\'t complete within {} seconds'.format(self._TIMEOUT)
                 )
                 raise TimeoutError
             if event.done:
-                logger.info('Deployment complete')
+                logger.info('Deployment complete - running: {}'.format(
+                    event.running
+                ))
                 return True
             logger.info(
-                'Deploying ECS tasks: desired {} running {}'.format(
-                    event.desired, event.running
+                'Deploying ECS tasks - '
+                'desired: {} pending: {} running: {} previous: {}'.format(
+                    event.desired, event.pending,
+                    event.running, event.previous_running
                 )
             )
 

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -1,0 +1,83 @@
+from hashlib import sha1
+
+
+def build_service_name(environment, component):
+    service_name = '{}-{}'.format(environment, component)
+    if len(service_name) > 32:
+        service_name_hash = sha1(service_name.encode('utf-8')).hexdigest()
+        service_name = '{}tf{}'.format(
+            service_name[:24], service_name_hash[:4]
+        )
+    return service_name
+
+
+class ECSEventIterator():
+
+    def __init__(self, cluster, environment, component, version, boto_session):
+        self._cluster = cluster
+        self._environment = environment
+        self._component = component
+        self._version = version
+        self._boto_session = boto_session
+        self._done = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._done:
+            raise StopIteration
+
+        ecs = self._boto_session.client('ecs')
+        service_name = build_service_name(self._environment, self._component)
+
+        services = ecs.describe_services(
+            cluster=self._cluster,
+            services=[service_name]
+        )
+
+        primary_deployment = [
+            deployment
+            for deployment in services['services'][0]['deployments']
+            if deployment['status'] == 'PRIMARY'
+        ][0]
+
+        task_def = ecs.describe_task_definition(
+            taskDefinition=primary_deployment['taskDefinition']
+        )['taskDefinition']['containerDefinitions'][0]
+
+        release_image = task_def['image'].split('/')[1]
+        if release_image != '{}:{}'.format(self._component, self._version):
+            raise ImageDoesNotMatchError
+
+        running = primary_deployment['runningCount']
+        desired = primary_deployment['desiredCount']
+        if running != desired:
+            return InProgressEvent(running, desired)
+
+        self._done = True
+        return DoneEvent(running, desired)
+
+
+class DoneEvent():
+
+    def __init__(self, running, desired):
+        self.done = True
+        self.running = running
+        self.desired = desired
+
+
+class InProgressEvent():
+
+    def __init__(self, running, desired):
+        self.done = False
+        self.running = running
+        self.desired = desired
+
+
+class TimeoutError(Exception):
+    pass
+
+
+class ImageDoesNotMatchError(Exception):
+    pass

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -151,8 +151,10 @@ class TimeoutError(UserError):
             TIMEOUT
         )
     )
-    pass
 
 
-class ImageDoesNotMatchError(Exception):
-    pass
+class ImageDoesNotMatchError(UserError):
+    _message = (
+        'Image for the PRIMARY deployment has changed (most likely due to '
+        'another deploy running'
+    )

--- a/cdflow_commands/logger.py
+++ b/cdflow_commands/logger.py
@@ -1,0 +1,7 @@
+import logging
+
+
+logging.basicConfig(format='[%(asctime)s] %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -304,9 +304,9 @@ class TestDeployCLI(unittest.TestCase):
         get_secrets.return_value = {}
 
         ECSEventIterator.return_value = [
-            InProgressEvent(0, 2),
-            InProgressEvent(1, 2),
-            DoneEvent(2, 2)
+            InProgressEvent(0, 0, 2, 0),
+            InProgressEvent(1, 0, 2, 0),
+            DoneEvent(2, 0, 2, 0)
         ]
         ECSMonitor._ITERATION_DELAY = 0
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -11,9 +11,10 @@ from mock import patch, Mock, mock_open, MagicMock, ANY
 from hypothesis import given, assume
 from hypothesis.strategies import text
 
+from cdflow_commands import ecs_monitor as ecs_monitor_module
 from cdflow_commands import cli
 from cdflow_commands.ecs_monitor import (
-    ECSMonitor, InProgressEvent, DoneEvent
+    InProgressEvent, DoneEvent
 )
 
 
@@ -308,7 +309,7 @@ class TestDeployCLI(unittest.TestCase):
             InProgressEvent(1, 0, 2, 0),
             DoneEvent(2, 0, 2, 0)
         ]
-        ECSMonitor._ITERATION_DELAY = 0
+        ecs_monitor_module.INTERVAL = 0
 
         # When
         with self.assertLogs('cdflow_commands.logger', level='INFO') as logs:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -37,7 +37,8 @@ class TestReleaseCLI(unittest.TestCase):
         mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
-                'account_id': 123456789
+                'account_id': 123456789,
+                'ecs_cluster.default.name': 'non-production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -45,7 +46,8 @@ class TestReleaseCLI(unittest.TestCase):
         mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
-                'account_id': 987654321
+                'account_id': 987654321,
+                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)
@@ -128,7 +130,8 @@ class TestReleaseCLI(unittest.TestCase):
         mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
-                'account_id': 123456789
+                'account_id': 123456789,
+                'ecs_cluster.default.name': 'production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -136,7 +139,8 @@ class TestReleaseCLI(unittest.TestCase):
         mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
-                'account_id': 987654321
+                'account_id': 987654321,
+                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)
@@ -240,7 +244,8 @@ class TestDeployCLI(unittest.TestCase):
         mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
-                'account_id': 123456789
+                'account_id': 123456789,
+                'ecs_cluster.default.name': 'non-production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -248,7 +253,8 @@ class TestDeployCLI(unittest.TestCase):
         mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
-                'account_id': 987654321
+                'account_id': 987654321,
+                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)
@@ -490,7 +496,8 @@ class TestDestroyCLI(unittest.TestCase):
         mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
-                'account_id': 123456789
+                'account_id': 123456789,
+                'ecs_cluster.default.name': 'non-production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -498,7 +505,8 @@ class TestDestroyCLI(unittest.TestCase):
         mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
-                'account_id': 987654321
+                'account_id': 987654321,
+                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -363,11 +363,11 @@ class TestDeployCLI(unittest.TestCase):
         )
 
         assert logs.output == [
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks: '
-             'desired 2 running 0'),
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks: '
-             'desired 2 running 1'),
-            'INFO:cdflow_commands.logger:Deployment complete'
+            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+             'desired: 2 pending: 0 running: 0 previous: 0'),
+            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+             'desired: 2 pending: 0 running: 1 previous: 0'),
+            'INFO:cdflow_commands.logger:Deployment complete - running: 2'
         ]
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -370,7 +370,9 @@ class TestDeployCLI(unittest.TestCase):
              'desired: 2 pending: 0 running: 0 previous: 0'),
             ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
              'desired: 2 pending: 0 running: 1 previous: 0'),
-            'INFO:cdflow_commands.logger:Deployment complete - running: 2'
+            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+             'desired: 2 pending: 0 running: 2 previous: 0'),
+            'INFO:cdflow_commands.logger:Deployment complete'
         ]
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -331,6 +331,7 @@ class TestDeployCLI(unittest.TestCase):
                 '-var', 'team=dummy-team',
                 '-var', 'image={}'.format(image_name),
                 '-var', 'version=1.2.3',
+                '-var', 'ecs_cluster=default',
                 '-var-file', 'infra/platform-config/mmg/dev/eu-west-12.json',
                 '-var-file', ANY,
                 'infra'
@@ -351,6 +352,7 @@ class TestDeployCLI(unittest.TestCase):
                 '-var', 'team=dummy-team',
                 '-var', 'image={}'.format(image_name),
                 '-var', 'version=1.2.3',
+                '-var', 'ecs_cluster=default',
                 '-var-file', 'infra/platform-config/mmg/dev/eu-west-12.json',
                 '-var-file', ANY,
                 'infra'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -71,7 +71,8 @@ class TestLoadConfig(unittest.TestCase):
         mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
-                'account_id': 123456789
+                'account_id': 123456789,
+                'ecs_cluster.default.name': 'non-production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -79,7 +80,8 @@ class TestLoadConfig(unittest.TestCase):
         mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
-                'account_id': 987654321
+                'account_id': 987654321,
+                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)
@@ -94,6 +96,8 @@ class TestLoadConfig(unittest.TestCase):
 
         assert global_config.dev_account_id == 123456789
         assert global_config.prod_account_id == 987654321
+        assert global_config.dev_ecs_cluster == 'non-production'
+        assert global_config.prod_ecs_cluster == 'production'
 
         file_path_template = 'infra/platform-config/{}/{}/{}.json'
         mock_open.assert_any_call(

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -49,7 +49,7 @@ def email(draw, min_size=7):
 class TestLoadConfig(unittest.TestCase):
 
     @patch('cdflow_commands.config.open', new_callable=mock_open, create=True)
-    def test_service_metadata_loaded(self, mock_open):
+    def test_service_metadata_loaded_with_default_ecs_cluster(self, mock_open):
         mock_file = MagicMock(spec=TextIOWrapper)
         expected_config = {
             'TEAM': 'dummy-team',
@@ -64,7 +64,33 @@ class TestLoadConfig(unittest.TestCase):
         assert metadata.type == expected_config['TYPE']
         assert metadata.aws_region == expected_config['REGION']
         assert metadata.account_prefix == expected_config['ACCOUNT_PREFIX']
+        assert metadata.ecs_cluster == 'default'
         mock_open.assert_called_once_with('service.json')
+
+    @given(text(alphabet=ascii_letters, min_size=8, max_size=32))
+    def test_service_metadata_loaded_with_specific_ecs_cluster(
+        self, ecs_cluster_name
+    ):
+        mock_file = MagicMock(spec=TextIOWrapper)
+        expected_config = {
+            'TEAM': 'dummy-team',
+            'TYPE': 'docker',
+            'REGION': 'eu-west-1',
+            'ACCOUNT_PREFIX': 'mmg',
+            'ECS_CLUSTER': ecs_cluster_name
+        }
+        with patch(
+            'cdflow_commands.config.open', new_callable=mock_open, create=True
+        ) as mocked_open:
+            mock_file.read.return_value = json.dumps(expected_config)
+            mocked_open.return_value.__enter__.return_value = mock_file
+            metadata = config.load_service_metadata()
+            assert metadata.team == expected_config['TEAM']
+            assert metadata.type == expected_config['TYPE']
+            assert metadata.aws_region == expected_config['REGION']
+            assert metadata.account_prefix == expected_config['ACCOUNT_PREFIX']
+            assert metadata.ecs_cluster == ecs_cluster_name
+            mocked_open.assert_called_once_with('service.json')
 
     @patch('cdflow_commands.config.open', new_callable=mock_open, create=True)
     def test_loaded_from_file(self, mock_open):

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -10,7 +10,7 @@ from mock import ANY
 from cdflow_commands.deploy import Deploy, DeployConfig
 
 
-IGNORED_PARAMS = [ANY] * 16
+IGNORED_PARAMS = [ANY] * 18
 CALL_KWARGS = 2
 
 
@@ -27,7 +27,7 @@ class TestDeploy(unittest.TestCase):
         )
         self._deploy = Deploy(
             boto_session, 'dummy-component', 'dummy-env',
-            'dummy-version', self._deploy_config
+            'dummy-version', 'dummy-ecs-cluster', self._deploy_config
         )
 
     @patch('cdflow_commands.deploy.check_call')
@@ -94,7 +94,7 @@ class TestDeploy(unittest.TestCase):
             credentials['session_token'],
             'eu-west-10'
         )
-        deploy = Deploy(boto_session, ANY, ANY, ANY, self._deploy_config)
+        deploy = Deploy(boto_session, ANY, ANY, ANY, ANY, self._deploy_config)
 
         with patch(
             'cdflow_commands.deploy.check_call'
@@ -148,7 +148,7 @@ class TestDeploy(unittest.TestCase):
             'eu-west-10'
         )
 
-        deploy = Deploy(boto_session, ANY, ANY, ANY, self._deploy_config)
+        deploy = Deploy(boto_session, ANY, ANY, ANY, ANY, self._deploy_config)
 
         with patch(
             'cdflow_commands.deploy.os'
@@ -195,7 +195,7 @@ class TestDeploy(unittest.TestCase):
             'eu-west-10'
         )
 
-        deploy = Deploy(boto_session, ANY, ANY, ANY, self._deploy_config)
+        deploy = Deploy(boto_session, ANY, ANY, ANY, ANY, self._deploy_config)
 
         with patch(
             'cdflow_commands.deploy.os'
@@ -223,6 +223,7 @@ class TestDeploy(unittest.TestCase):
         'component_name': text(alphabet=printable, min_size=2, max_size=30),
         'environment_name': text(alphabet=printable, min_size=2, max_size=10),
         'version': text(alphabet=printable, min_size=1, max_size=20),
+        'ecs_cluster': text(alphabet=ascii_letters, min_size=8, max_size=32),
         'platform_config_file': text(
             alphabet=printable, min_size=10, max_size=30
         ),
@@ -245,6 +246,7 @@ class TestDeploy(unittest.TestCase):
             data['component_name'],
             data['environment_name'],
             data['version'],
+            data['ecs_cluster'],
             deploy_config
         )
         image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
@@ -278,6 +280,7 @@ class TestDeploy(unittest.TestCase):
                 '-var', 'team={}'.format(data['team']),
                 '-var', 'image={}'.format(image_name),
                 '-var', 'version={}'.format(data['version']),
+                '-var', 'ecs_cluster={}'.format(data['ecs_cluster']),
                 '-var-file', data['platform_config_file'],
                 '-var-file', secret_file_path,
                 'infra'
@@ -307,7 +310,7 @@ class TestEnvironmentSpecificConfigAddedToTerraformArgs(unittest.TestCase):
         )
         deploy = Deploy(
             boto_session, 'dummy-component', env_name,
-            'dummy-version', deploy_config
+            'dummy-version', 'dummy-ecs-cluster', deploy_config
         )
 
         # When
@@ -337,6 +340,7 @@ class TestEnvironmentSpecificConfigAddedToTerraformArgs(unittest.TestCase):
                 '-var', 'team=dummy-team',
                 '-var', 'image={}'.format(image_name),
                 '-var', 'version=dummy-version',
+                '-var', 'ecs_cluster=dummy-ecs-cluster',
                 '-var-file', 'dummy-platform-config-file',
                 '-var-file', ANY,
                 '-var-file', config_file,

--- a/test/test_destroy.py
+++ b/test/test_destroy.py
@@ -1,15 +1,15 @@
 import unittest
 
 from string import printable
+from collections import namedtuple
 
-from mock import patch, ANY
+from mock import patch, ANY, Mock
 from hypothesis import given
 from hypothesis.strategies import text, dictionaries, fixed_dictionaries
 
-from boto3 import Session
-
 from cdflow_commands.destroy import Destroy
 
+BotoCreds = namedtuple('BotoCreds', ['access_key', 'secret_key', 'token'])
 
 CALL_KWARGS = 2
 
@@ -24,9 +24,11 @@ class TestDestroy(unittest.TestCase):
     def test_plan_was_called_via_terragrunt(self, test_fixtures):
         component_name = test_fixtures['component_name']
         environment_name = test_fixtures['environment_name']
-        boto_session = Session('ANY', 'ANY', 'ANY', test_fixtures['region'])
+
+        boto_session = Mock()
+        boto_session.region_name = test_fixtures['region']
         destroy = Destroy(
-            boto_session, component_name, environment_name
+            boto_session, component_name, environment_name, 'dummy-bucket'
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
@@ -45,9 +47,10 @@ class TestDestroy(unittest.TestCase):
     def test_destroy_was_called_via_terragrunt(self, test_fixtures):
         component_name = test_fixtures['component_name']
         environment_name = test_fixtures['environment_name']
-        boto_session = Session('ANY', 'ANY', 'ANY', test_fixtures['region'])
+        boto_session = Mock()
+        boto_session.region_name = test_fixtures['region']
         destroy = Destroy(
-            boto_session, component_name, environment_name
+            boto_session, component_name, environment_name, 'dummy-bucket'
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
@@ -64,14 +67,16 @@ class TestDestroy(unittest.TestCase):
         'session_token': text(alphabet=printable, min_size=1),
     }))
     def test_aws_config_was_passed_into_envionrment(self, aws_config):
-        boto_session = Session(
+        boto_session = Mock()
+        boto_session.region_name = 'dummy-region'
+        boto_session.get_credentials.return_value = BotoCreds(
             aws_config['access_key'],
             aws_config['secret_key'],
             aws_config['session_token'],
-            'dummy-region'
         )
         destroy = Destroy(
-            boto_session, 'dummy-component', 'dummy-environment'
+            boto_session, 'dummy-component',
+            'dummy-environment', 'dummy-bucket'
         )
 
         with patch('cdflow_commands.destroy.check_call') as check_call:
@@ -93,14 +98,16 @@ class TestDestroy(unittest.TestCase):
         min_size=1
     ))
     def test_original_environment_was_preserved(self, mock_env):
-        boto_session = Session(
+        boto_session = Mock()
+        boto_session.region_name = 'dummy-region'
+        boto_session.get_credentials.return_value = BotoCreds(
             'dummy-access-key',
             'dummy-secret-key',
             'dummy-session-token',
-            'dummy-region'
         )
         destroy = Destroy(
-            boto_session, 'dummy-component', 'dummy-environment'
+            boto_session, 'dummy-component',
+            'dummy-environment', 'dummy-bucket'
         )
 
         with patch(
@@ -118,3 +125,39 @@ class TestDestroy(unittest.TestCase):
             env = check_call.mock_calls[1][CALL_KWARGS]['env']
             for key, value in mock_env.items():
                 assert env[key] == value
+
+    @given(fixed_dictionaries({
+        'component_name': text(alphabet=printable, min_size=1),
+        'environment_name': text(alphabet=printable, min_size=1),
+        's3_bucket_name': text(alphabet=printable, min_size=1),
+    }))
+    def test_tfstate_removed_from_s3(self, test_fixtures):
+        # Given
+        boto_session = Mock()
+        boto_session.region_name = 'dummy-region'
+        boto_session.get_credentials.return_value = BotoCreds(
+            'dummy-access-key',
+            'dummy-secret-key',
+            'dummy-session-token',
+        )
+        boto_s3_client = Mock()
+        boto_session.client.return_value = boto_s3_client
+        destroy = Destroy(
+            boto_session,
+            test_fixtures['component_name'],
+            test_fixtures['environment_name'],
+            test_fixtures['s3_bucket_name']
+        )
+
+        # When
+        with patch('cdflow_commands.destroy.check_call'):
+            destroy.run()
+
+        # Then
+        boto_s3_client.delete_object.assert_any_call(
+            Bucket=test_fixtures['s3_bucket_name'],
+            Key='{}/{}/tfstate.json'.format(
+                test_fixtures['environment_name'],
+                test_fixtures['component_name']
+            )
+        )

--- a/test/test_destroy.py
+++ b/test/test_destroy.py
@@ -156,7 +156,7 @@ class TestDestroy(unittest.TestCase):
         # Then
         boto_s3_client.delete_object.assert_any_call(
             Bucket=test_fixtures['s3_bucket_name'],
-            Key='{}/{}/tfstate.json'.format(
+            Key='{}/{}/terraform.tfstate'.format(
                 test_fixtures['environment_name'],
                 test_fixtures['component_name']
             )

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -1,0 +1,91 @@
+import unittest
+
+from mock import MagicMock, Mock
+
+from boto3 import Session
+
+
+class TestECSMonitor(unittest.TestCase):
+
+    @given(fixed_dictionaries({
+        'environment': text(),
+        'component': text(),
+        'version': text()
+    }))
+    def test_monitor_exited_when_the_deployment_is_stable(
+        self, deployment_data
+    ):
+        environment = deployment_data['environment']
+        component = deployment_data['component']
+        version = deployment_data['version']
+        boto_session = MagicMock(spec=Session)
+        mock_ecs_client = Mock()
+        mock_ecs_client.describe_services.return_value = {
+            'ResponseMetadata': {
+                'HTTPHeaders': {
+                    'connection': 'keep-alive',
+                    'content-length': '23785',
+                    'content-type': 'application/x-amz-json-1.1',
+                    'date': 'Tue, 28 Feb 2017 16:31:06 GMT',
+                    'server': 'Server',
+                    'x-amzn-requestid': '4d9c8983-fdd3-11e6-99ed-6bb93e41be46'
+                },
+                'HTTPStatusCode': 200,
+                'RequestId': '4d9c8983-fdd3-11e6-99ed-6bb93e41be46',
+                'RetryAttempts': 0
+            },
+            'failures': [],
+            'services': [
+                {
+                    'clusterArn': 'arn:aws:ecs:eu-1:7:cluster/non-production',
+                    'createdAt': datetime.datetime(2017, 1, 6, 10, 58, 9),
+                    'deploymentConfiguration': {
+                        'maximumPercent': 200,
+                        'minimumHealthyPercent': 100
+                    },
+                   'deployments': [
+                        {
+                            'createdAt': datetime.datetime(2017, 1, 6, 13, 57),
+                            'desiredCount': 2,
+                            'id': 'ecs-svc/9223370553143707624',
+                            'pendingCount': 0,
+                            'runningCount': 2,
+                            'status': 'PRIMARY',
+                            'taskDefinition': 'aslive-test:3',
+                            'updatedAt': datetime.datetime(2017, 1, 6, 13, 57)
+                        }
+                    ],
+                    'desiredCount': 2,
+                    'events': [
+                        {
+                            'createdAt': datetime.datetime(2017, 2, 28, 15),
+                            'id': '59d4860e-5734-485e-ad4c-5205193f858e',
+                            'message': '(service aslive-testtf2469) '
+                                      'has reached a steady state.'
+                        }
+                    ],
+                    'loadBalancers': [
+                        {
+                            'containerName': 'app',
+                            'containerPort': 8000,
+                            'targetGroupArn': 'd035fe071cf0069f'
+                        }
+                    ],
+                   'pendingCount': 0,
+                   'placementConstraints': [],
+                   'placementStrategy': [],
+                   'roleArn': '20170106105800480922659dsq',
+                   'runningCount': 2,
+                   'serviceArn': 'aslive-testtf2469',
+                   'serviceName': 'aslive-testtf2469',
+                   'status': 'ACTIVE',
+                   'taskDefinition': 'aslive-test:3'
+                }
+            ]
+        }
+        boto_session.client.return_value = mock_ecs_client
+        monitor = ECSMonitor(environment, component, version, boto_session)
+
+        monitor.wait()
+
+        boto_session.client.assert_any_call('ecs')

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -1,49 +1,45 @@
 import unittest
+import datetime
+from itertools import islice
 
 from mock import MagicMock, Mock
+from hypothesis import given, settings
+from hypothesis.strategies import text, fixed_dictionaries
 
 from boto3 import Session
 
+from cdflow_commands.ecs_monitor import (
+    ECSEventIterator, build_service_name, ImageDoesNotMatchError
+)
 
-class TestECSMonitor(unittest.TestCase):
+
+class TestECSEventIterator(unittest.TestCase):
 
     @given(fixed_dictionaries({
+        'cluster': text(),
         'environment': text(),
         'component': text(),
         'version': text()
     }))
+    @settings(max_examples=5)
     def test_monitor_exited_when_the_deployment_is_stable(
         self, deployment_data
     ):
         environment = deployment_data['environment']
         component = deployment_data['component']
         version = deployment_data['version']
+        cluster = deployment_data['cluster']
         boto_session = MagicMock(spec=Session)
         mock_ecs_client = Mock()
+        task_definition_arn = ('arn:aws:ecs:eu-west-3:111111111111:'
+                               'task-definition/{}:1'.format(component)),
         mock_ecs_client.describe_services.return_value = {
-            'ResponseMetadata': {
-                'HTTPHeaders': {
-                    'connection': 'keep-alive',
-                    'content-length': '23785',
-                    'content-type': 'application/x-amz-json-1.1',
-                    'date': 'Tue, 28 Feb 2017 16:31:06 GMT',
-                    'server': 'Server',
-                    'x-amzn-requestid': '4d9c8983-fdd3-11e6-99ed-6bb93e41be46'
-                },
-                'HTTPStatusCode': 200,
-                'RequestId': '4d9c8983-fdd3-11e6-99ed-6bb93e41be46',
-                'RetryAttempts': 0
-            },
             'failures': [],
             'services': [
                 {
                     'clusterArn': 'arn:aws:ecs:eu-1:7:cluster/non-production',
                     'createdAt': datetime.datetime(2017, 1, 6, 10, 58, 9),
-                    'deploymentConfiguration': {
-                        'maximumPercent': 200,
-                        'minimumHealthyPercent': 100
-                    },
-                   'deployments': [
+                    'deployments': [
                         {
                             'createdAt': datetime.datetime(2017, 1, 6, 13, 57),
                             'desiredCount': 2,
@@ -51,19 +47,11 @@ class TestECSMonitor(unittest.TestCase):
                             'pendingCount': 0,
                             'runningCount': 2,
                             'status': 'PRIMARY',
-                            'taskDefinition': 'aslive-test:3',
+                            'taskDefinition': task_definition_arn,
                             'updatedAt': datetime.datetime(2017, 1, 6, 13, 57)
                         }
                     ],
                     'desiredCount': 2,
-                    'events': [
-                        {
-                            'createdAt': datetime.datetime(2017, 2, 28, 15),
-                            'id': '59d4860e-5734-485e-ad4c-5205193f858e',
-                            'message': '(service aslive-testtf2469) '
-                                      'has reached a steady state.'
-                        }
-                    ],
                     'loadBalancers': [
                         {
                             'containerName': 'app',
@@ -71,21 +59,333 @@ class TestECSMonitor(unittest.TestCase):
                             'targetGroupArn': 'd035fe071cf0069f'
                         }
                     ],
-                   'pendingCount': 0,
-                   'placementConstraints': [],
-                   'placementStrategy': [],
-                   'roleArn': '20170106105800480922659dsq',
-                   'runningCount': 2,
-                   'serviceArn': 'aslive-testtf2469',
-                   'serviceName': 'aslive-testtf2469',
-                   'status': 'ACTIVE',
-                   'taskDefinition': 'aslive-test:3'
+                    'pendingCount': 0,
+                    'roleArn': '20170106105800480922659dsq',
+                    'runningCount': 2,
+                    'serviceArn': 'aslive-testtf2469',
+                    'serviceName': 'aslive-testtf2469',
+                    'status': 'ACTIVE',
+                    'taskDefinition': task_definition_arn
                 }
             ]
         }
+        mock_ecs_client.describe_task_definition.return_value = {
+            'taskDefinition': {
+                'containerDefinitions': [{
+                    'cpu': 64,
+                    'dockerLabels': {
+                        'component': component,
+                        'env': 'ci',
+                        'team': 'platform',
+                        'version': '123'
+                    },
+                    'environment': [
+                        {
+                            'name': 'VERSION',
+                            'value': version
+                        },
+                        {
+                            'name': 'COMPONENT',
+                            'value': component
+                        },
+                    ],
+                    'essential': True,
+                    'image': ('111111111111.dkr.ecr.eu-west-1.amazonaws.com/'
+                              '{}:{}'.format(component, version)),
+                    'volumesFrom': []
+                }],
+                'status': 'ACTIVE',
+                'taskDefinitionArn': task_definition_arn,
+                'taskRoleArn': 'arn:aws:iam::7:role/role',
+                'volumes': []
+            }
+        }
         boto_session.client.return_value = mock_ecs_client
-        monitor = ECSMonitor(environment, component, version, boto_session)
+        events = ECSEventIterator(
+            cluster, environment, component, version, boto_session
+        )
 
-        monitor.wait()
+        event_list = [e for e in events]
 
-        boto_session.client.assert_any_call('ecs')
+        assert len(event_list) == 1
+        assert event_list[0].done
+
+    def test_monitor_exited_deploy_finished_after_3_iterations(self):
+        environment = 'dummy-environment'
+        component = 'dummy-component'
+        version = 'dummy-version'
+        cluster = 'dummy-cluster'
+        boto_session = MagicMock(spec=Session)
+        mock_ecs_client = Mock()
+        task_definition_arn = ('arn:aws:ecs:eu-west-3:111111111111:'
+                               'task-definition/{}:1'.format(component)),
+
+        def describe_services_generator(final_running_count):
+            for running_count in range(final_running_count + 1):
+                yield {
+                    'services': [
+                        {
+                            'clusterArn': 'arn:aws:ecs:eu-1:7:cstr/non-prod',
+                            'deployments': [
+                                {
+                                    'desiredCount': 2,
+                                    'id': 'ecs-svc/9223370553143707624',
+                                    'runningCount': running_count,
+                                    'status': 'PRIMARY',
+                                    'taskDefinition': task_definition_arn,
+                                },
+                                {
+                                    'desiredCount': 2,
+                                    'id': 'ecs-svc/9223370553143707624',
+                                    'runningCount': 2,
+                                    'status': 'ACTIVE',
+                                    'taskDefinition': task_definition_arn,
+                                }
+                            ],
+                            'loadBalancers': [
+                                {
+                                    'containerName': 'app',
+                                    'containerPort': 8000,
+                                    'targetGroupArn': 'd035fe071cf0069f'
+                                }
+                            ],
+                            'status': 'ACTIVE',
+                            'taskDefinition': task_definition_arn
+                        }
+                    ]
+                }
+
+        mock_ecs_client.describe_services.side_effect = \
+            describe_services_generator(2)
+
+        mock_ecs_client.describe_task_definition.return_value = {
+            'taskDefinition': {
+                'containerDefinitions': [{
+                    'cpu': 64,
+                    'dockerLabels': {
+                        'component': component,
+                        'env': 'ci',
+                        'team': 'platform',
+                        'version': '123'
+                    },
+                    'environment': [
+                        {
+                            'name': 'VERSION',
+                            'value': version
+                        },
+                        {
+                            'name': 'COMPONENT',
+                            'value': component
+                        },
+                    ],
+                    'essential': True,
+                    'image': ('111111111111.dkr.ecr.eu-west-1.amazonaws.com/'
+                              '{}:{}'.format(component, version)),
+                    'volumesFrom': []
+                }],
+                'status': 'ACTIVE',
+                'taskDefinitionArn': task_definition_arn,
+                'taskRoleArn': 'arn:aws:iam::7:role/role',
+                'volumes': []
+            }
+        }
+        boto_session.client.return_value = mock_ecs_client
+        events = ECSEventIterator(
+            cluster, environment, component, version, boto_session
+        )
+
+        event_list = [e for e in events]
+
+        assert len(event_list) == 3
+        assert not event_list[0].done
+        assert event_list[0].running == 0
+        assert event_list[0].desired == 2
+        assert not event_list[1].done
+        assert event_list[1].running == 1
+        assert event_list[1].desired == 2
+        assert event_list[2].done
+        assert event_list[2].running == 2
+        assert event_list[2].desired == 2
+
+    def test_deployment_does_not_complete_within_time(self):
+        environment = 'dummy-environment'
+        component = 'dummy-component'
+        version = 'dummy-version'
+        cluster = 'dummy-cluster'
+        boto_session = MagicMock(spec=Session)
+        mock_ecs_client = Mock()
+        task_definition_arn = ('arn:aws:ecs:eu-west-3:111111111111:'
+                               'task-definition/{}:1'.format(component)),
+
+        mock_ecs_client.describe_services.return_value = {
+            'services': [
+                {
+                    'clusterArn': 'arn:aws:ecs:eu-1:7:cstr/non-prod',
+                    'deployments': [
+                        {
+                            'desiredCount': 2,
+                            'id': 'ecs-svc/9223370553143707624',
+                            'runningCount': 1,
+                            'status': 'PRIMARY',
+                            'taskDefinition': task_definition_arn,
+                        }
+                    ],
+                    'status': 'ACTIVE',
+                    'taskDefinition': task_definition_arn
+                }
+            ]
+        }
+
+        mock_ecs_client.describe_task_definition.return_value = {
+            'taskDefinition': {
+                'containerDefinitions': [{
+                    'cpu': 64,
+                    'dockerLabels': {
+                        'component': component,
+                        'env': 'ci',
+                        'team': 'platform',
+                        'version': '123'
+                    },
+                    'image': ('111111111111.dkr.ecr.eu-west-1.amazonaws.com/'
+                              '{}:{}'.format(component, version)),
+                }],
+                'status': 'ACTIVE',
+                'taskDefinitionArn': task_definition_arn,
+                'taskRoleArn': 'arn:aws:iam::7:role/role',
+                'volumes': []
+            }
+        }
+        boto_session.client.return_value = mock_ecs_client
+        events = ECSEventIterator(
+            cluster, environment, component, version, boto_session
+        )
+        statuses = [e.done for e in islice(events, 1000)]
+        assert not any(statuses)
+
+    @given(fixed_dictionaries({
+        'environment': text(),
+        'component': text(),
+        'version': text()
+    }))
+    @settings(max_examples=5)
+    def test_monitor_image_does_not_match(
+        self, deployment_data
+    ):
+        environment = deployment_data['environment']
+        component = deployment_data['component']
+        version = deployment_data['version']
+        cluster = 'ecs-cluster'
+        boto_session = MagicMock(spec=Session)
+        mock_ecs_client = Mock()
+        task_definition_arn = ('arn:aws:ecs:eu-west-3:111111111111:'
+                               'task-definition/{}:1'.format(component)),
+        mock_ecs_client.describe_services.return_value = {
+            'services': [
+                {
+                    'clusterArn': 'arn:aws:ecs:eu-1:7:cluster/non-production',
+                    'deployments': [
+                        {
+                            'desiredCount': 2,
+                            'id': 'ecs-svc/9223370553143707624',
+                            'pendingCount': 0,
+                            'runningCount': 2,
+                            'status': 'PRIMARY',
+                            'taskDefinition': task_definition_arn,
+                            'updatedAt': datetime.datetime(2017, 1, 6, 13, 57)
+                        }
+                    ],
+                    'status': 'ACTIVE',
+                    'taskDefinition': task_definition_arn
+                }
+            ]
+        }
+        mock_ecs_client.describe_task_definition.return_value = {
+            'taskDefinition': {
+                'containerDefinitions': [{
+                    'dockerLabels': {
+                        'component': component,
+                        'env': 'ci',
+                        'team': 'platform',
+                        'version': '123'
+                    },
+                    'environment': [
+                        {
+                            'name': 'VERSION',
+                            'value': version
+                        },
+                        {
+                            'name': 'COMPONENT',
+                            'value': component
+                        },
+                    ],
+                    'image': 'ecr/none',
+                }],
+                'taskDefinitionArn': task_definition_arn,
+            }
+        }
+        boto_session.client.return_value = mock_ecs_client
+        events = ECSEventIterator(
+            cluster, environment, component, version, boto_session
+        )
+
+        self.assertRaises(ImageDoesNotMatchError, lambda: [e for e in events])
+
+
+class TestBuildServiceName(unittest.TestCase):
+
+    @given(fixed_dictionaries({
+        'environment': text(max_size=6),
+        'component': text(max_size=25),
+    }))
+    def test_build_service_name_short_name(self, test_data):
+        # Given
+        # When
+        service_name = build_service_name(
+            test_data['environment'], test_data['component']
+        )
+        # Then
+        assert service_name == "{}-{}".format(
+            test_data['environment'], test_data['component']
+        )
+
+    @given(fixed_dictionaries({
+        'environment': text(min_size=6),
+        'component': text(min_size=26),
+    }))
+    def test_build_service_name_long_name(self, test_data):
+        # When
+        service_name = build_service_name(
+            test_data['environment'], test_data['component']
+        )
+        # Then
+        assert service_name.startswith("{}-{}".format(
+            test_data['environment'], test_data['component']
+        )[:24])
+
+    @given(fixed_dictionaries({
+        'environment': text(min_size=6),
+        'component': text(min_size=26),
+    }))
+    def test_build_service_name_length_limit(self, test_data):
+        # When
+        service_name = build_service_name(
+            test_data['environment'], test_data['component']
+        )
+        # Then
+        assert len(service_name) <= 32
+
+    @given(fixed_dictionaries({
+        'environment': text(min_size=6),
+        'component': text(min_size=26),
+    }))
+    def test_build_service_name_idempotent(self, test_data):
+        # Given
+        service_name_1 = build_service_name(
+            test_data['environment'], test_data['component']
+        )
+        # When
+        service_name_2 = build_service_name(
+            test_data['environment'], test_data['component']
+        )
+        # Then
+        assert service_name_1 == service_name_2

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -3,7 +3,7 @@ import datetime
 from itertools import cycle, islice
 
 from mock import MagicMock, Mock
-from hypothesis import given, settings
+from hypothesis import given, settings, example
 from hypothesis.strategies import text, fixed_dictionaries
 
 from boto3 import Session
@@ -86,6 +86,12 @@ class TestECSEventIterator(unittest.TestCase):
         'component': text(),
         'version': text()
     }))
+    @example({
+        'cluster': '',
+        'environment': '',
+        'component': 'hello/world',
+        'version': '1'
+    })
     @settings(max_examples=5)
     def test_monitor_exited_when_the_deployment_is_stable(
         self, deployment_data

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -196,6 +196,8 @@ class TestECSEventIterator(unittest.TestCase):
 
         event_list = [e for e in events]
 
+        mock_ecs_client.describe_task_definition.assert_called_once()
+
         assert len(event_list) == 3
         assert not event_list[0].done
         assert event_list[0].running == 0

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -30,7 +30,9 @@ class TestECSMonitor(unittest.TestCase):
 
         # Then
         assert logs.output == [
-            'INFO:cdflow_commands.logger:Deployment complete - running: 2'
+            ('INFO:cdflow_commands.logger:Deploying ECS tasks - desired: 2 '
+             'pending: 0 running: 2 previous: 0'),
+            'INFO:cdflow_commands.logger:Deployment complete'
         ]
 
     def test_ecs_monitor_eventual_successful_deployment(self):
@@ -53,7 +55,9 @@ class TestECSMonitor(unittest.TestCase):
              'desired: 2 pending: 1 running: 0 previous: 2'),
             ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
              'desired: 2 pending: 0 running: 1 previous: 1'),
-            'INFO:cdflow_commands.logger:Deployment complete - running: 2'
+            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+             'desired: 2 pending: 0 running: 2 previous: 0'),
+            'INFO:cdflow_commands.logger:Deployment complete'
         ]
 
     def test_ecs_monitor_deployment_times_out(self):


### PR DESCRIPTION
Once Terraform has completed the changes to the infrastructure we'd like to get feedback for the user as to whether the new version of the service is running.

This adds in logic to query ECS for the running service and checks that the desired number of instances of the requested version are running.

Example output:
```
[terragrunt] 2017/03/06 16:59:16 Lock released!
[2017-03-06 17:00:17] Deploying ECS tasks - desired: 2 pending: 0 running: 0 previous: 2
[2017-03-06 17:00:32] Deploying ECS tasks - desired: 2 pending: 0 running: 0 previous: 2
[2017-03-06 17:00:47] Deploying ECS tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-06 17:01:02] Deploying ECS tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-06 17:01:17] Deploying ECS tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-06 17:01:32] Deploying ECS tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-06 17:01:47] Deployment complete - running: 2
```