### PR TITLE
Adds the ability to display debug messages

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -9,8 +9,10 @@ Usage:
 
 Options:
     -c <component_name>, --component <component_name>
+    -v, --verbose
 
 """
+import logging
 import os
 import sys
 
@@ -28,9 +30,10 @@ from cdflow_commands.config import (
 from cdflow_commands.release import Release, ReleaseConfig
 from cdflow_commands.deploy import Deploy, DeployConfig
 from cdflow_commands.destroy import Destroy
-from cdflow_commands.terragrunt import S3BucketFactory, write_terragrunt_config
 from cdflow_commands.ecs_monitor import ECSEventIterator, ECSMonitor
 from cdflow_commands.exceptions import UserError
+from cdflow_commands.logger import logger
+from cdflow_commands.terragrunt import S3BucketFactory, write_terragrunt_config
 
 
 def run(argv):
@@ -42,6 +45,9 @@ def run(argv):
 
 def _run(argv):
     args = docopt(__doc__, argv=argv)
+    if args['--verbose']:
+        logger.setLevel(logging.DEBUG)
+        logger.debug('Debug logging on')
     metadata = load_service_metadata()
     global_config = load_global_config(
         metadata.account_prefix, metadata.aws_region

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,6 +16,7 @@ from cdflow_commands import cli
 from cdflow_commands.ecs_monitor import (
     InProgressEvent, DoneEvent
 )
+from cdflow_commands.exceptions import UserError
 
 
 class TestReleaseCLI(unittest.TestCase):
@@ -605,3 +606,30 @@ class TestDestroyCLI(unittest.TestCase):
                 'AWS_SESSION_TOKEN': aws_session_token
             }
         )
+
+
+class TestVerboseLogging(unittest.TestCase):
+
+    @patch('cdflow_commands.cli.load_service_metadata')
+    def test_verbose_flag_in_arguments(self, load_service_metadata):
+        # Given
+        load_service_metadata.side_effect = UserError
+
+        # When
+        with self.assertLogs('cdflow_commands.logger', level='DEBUG') as logs:
+            cli.run(['release', 'version', '--verbose'])
+
+        # Then
+        assert 'DEBUG:cdflow_commands.logger:Debug logging on' in logs.output
+
+    @patch('cdflow_commands.cli.load_service_metadata')
+    def test_short_verbose_flag_in_arguments(self, load_service_metadata):
+        # Given
+        load_service_metadata.side_effect = UserError
+
+        # When
+        with self.assertLogs('cdflow_commands.logger', level='DEBUG') as logs:
+            cli.run(['release', 'version', '-v'])
+
+        # Then
+        assert 'DEBUG:cdflow_commands.logger:Debug logging on' in logs.output


### PR DESCRIPTION
This adds a `--verbose` flag which toggles the display of debug
messages on the command line for degbugging purposes.

JIRA: PLAT-837