### PR TITLE
Removes logic which loads cluster name from config

### DIFF
--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -35,9 +35,7 @@ Metadata = namedtuple(
 GlobalConfig = namedtuple(
     'GlobalConfig', [
         'dev_account_id',
-        'prod_account_id',
-        'dev_ecs_cluster',
-        'prod_ecs_cluster'
+        'prod_account_id'
     ]
 )
 
@@ -55,25 +53,19 @@ def load_service_metadata():
 
 
 def load_global_config(account_prefix, aws_region):
-    ecs_cluster = 'default'
-    ecs_cluster_key = 'ecs_cluster.{}.name'.format(ecs_cluster)
     with open(get_platform_config_path(
         account_prefix, aws_region, is_prod=False
     )) as f:
         config = json.loads(f.read())
         dev_account_id = config['platform_config']['account_id']
-        dev_ecs_cluster = config['platform_config'][ecs_cluster_key]
 
     with open(get_platform_config_path(
         account_prefix, aws_region, is_prod=True
     )) as f:
         config = json.loads(f.read())
         prod_account_id = config['platform_config']['account_id']
-        prod_ecs_cluster = config['platform_config'][ecs_cluster_key]
 
-    return GlobalConfig(
-        dev_account_id, prod_account_id, dev_ecs_cluster, prod_ecs_cluster
-    )
+    return GlobalConfig(dev_account_id, prod_account_id)
 
 
 def assume_role(root_session, acccount_id, session_name):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -46,7 +46,6 @@ class TestReleaseCLI(unittest.TestCase):
         dev_config = {
             'platform_config': {
                 'account_id': 123456789,
-                'ecs_cluster.default.name': 'non-production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -55,7 +54,6 @@ class TestReleaseCLI(unittest.TestCase):
         prod_config = {
             'platform_config': {
                 'account_id': 987654321,
-                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)
@@ -133,7 +131,6 @@ class TestReleaseCLI(unittest.TestCase):
         dev_config = {
             'platform_config': {
                 'account_id': 123456789,
-                'ecs_cluster.default.name': 'production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -142,7 +139,6 @@ class TestReleaseCLI(unittest.TestCase):
         prod_config = {
             'platform_config': {
                 'account_id': 987654321,
-                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)
@@ -250,7 +246,6 @@ class TestDeployCLI(unittest.TestCase):
         dev_config = {
             'platform_config': {
                 'account_id': 123456789,
-                'ecs_cluster.default.name': 'non-production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -259,7 +254,6 @@ class TestDeployCLI(unittest.TestCase):
         prod_config = {
             'platform_config': {
                 'account_id': 987654321,
-                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)
@@ -531,7 +525,6 @@ class TestDestroyCLI(unittest.TestCase):
         dev_config = {
             'platform_config': {
                 'account_id': 123456789,
-                'ecs_cluster.default.name': 'non-production'
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -540,7 +533,6 @@ class TestDestroyCLI(unittest.TestCase):
         prod_config = {
             'platform_config': {
                 'account_id': 987654321,
-                'ecs_cluster.default.name': 'production'
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -97,8 +97,7 @@ class TestLoadConfig(unittest.TestCase):
         mock_dev_file = MagicMock(spec=TextIOWrapper)
         dev_config = {
             'platform_config': {
-                'account_id': 123456789,
-                'ecs_cluster.default.name': 'non-production'
+                'account_id': 123456789
             }
         }
         mock_dev_file.read.return_value = json.dumps(dev_config)
@@ -106,8 +105,7 @@ class TestLoadConfig(unittest.TestCase):
         mock_prod_file = MagicMock(spec=TextIOWrapper)
         prod_config = {
             'platform_config': {
-                'account_id': 987654321,
-                'ecs_cluster.default.name': 'production'
+                'account_id': 987654321
             }
         }
         mock_prod_file.read.return_value = json.dumps(prod_config)
@@ -122,8 +120,6 @@ class TestLoadConfig(unittest.TestCase):
 
         assert global_config.dev_account_id == 123456789
         assert global_config.prod_account_id == 987654321
-        assert global_config.dev_ecs_cluster == 'non-production'
-        assert global_config.prod_ecs_cluster == 'production'
 
         file_path_template = 'infra/platform-config/{}/{}/{}.json'
         mock_open.assert_any_call(


### PR DESCRIPTION
We've removed the indirection with loading the ECS cluster name from
the config so this logic doesn't apply, and indeed causes failures
when using the latest version of the config.

JIRA: PLAT-846