### PR TITLE
PLAT-826 - Monitor task healthiness during the deploy & fail if any of the tasks failed

### DIFF
--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -198,8 +198,7 @@ class TimeoutError(UserError):
 
 class FailedTasksError(UserError):
     _message = (
-        ('Deployment failed - tasks (containers) are '
-         'failing to pass healthcheck')
+        'Deployment failed - number of running tasks has decreased'
     )
 
 

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -30,18 +30,26 @@ class ECSMonitor():
         for event in self._ecs_event_iterator:
             if time() - start > TIMEOUT:
                 raise TimeoutError
-            logger.info(
-                'Deploying ECS tasks - '
-                'desired: {} pending: {} running: {} previous: {}'.format(
-                    event.desired, event.pending,
-                    event.running, event.previous_running
-                )
-            )
+
+            self._show_deployment_progress(event)
+
             if event.done:
                 logger.info('Deployment complete')
                 return True
 
             sleep(INTERVAL)
+
+    def _show_deployment_progress(self, event):
+        for message in event.messages:
+            logger.info("ECS service event - {}".format(message))
+
+        logger.info(
+            'ECS service tasks - '
+            'desired: {} pending: {} running: {} previous: {}'.format(
+                event.desired, event.pending,
+                event.running, event.previous_running
+            )
+        )
 
 
 class ECSEventIterator():

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -62,7 +62,12 @@ class ECSEventIterator():
         if self._done:
             raise StopIteration
 
-        deployments = self._get_deployments()
+        ecs_service_data = self._ecs.describe_services(
+            cluster=self._cluster,
+            services=[self.service_name]
+        )
+
+        deployments = self._get_deployments(ecs_service_data)
         primary_deployment = self._get_primary_deployment(deployments)
         release_image = self._get_release_image(
             primary_deployment['taskDefinition']
@@ -121,14 +126,10 @@ class ECSEventIterator():
 
         return task_def['image'].split('/', 1)[1]
 
-    def _get_deployments(self):
-        services = self._ecs.describe_services(
-            cluster=self._cluster,
-            services=[self.service_name]
-        )
+    def _get_deployments(self, ecs_service_data):
         return [
             deployment
-            for deployment in services['services'][0]['deployments']
+            for deployment in ecs_service_data['services'][0]['deployments']
         ]
 
     def _get_primary_deployment(self, deployments):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -299,9 +299,9 @@ class TestDeployCLI(unittest.TestCase):
         get_secrets.return_value = {}
 
         ECSEventIterator.return_value = [
-            InProgressEvent(0, 0, 2, 0),
-            InProgressEvent(1, 0, 2, 0),
-            DoneEvent(2, 0, 2, 0)
+            InProgressEvent(0, 0, 2, 0, []),
+            InProgressEvent(1, 0, 2, 0, []),
+            DoneEvent(2, 0, 2, 0, [])
         ]
         ecs_monitor_module.INTERVAL = 0
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -360,11 +360,11 @@ class TestDeployCLI(unittest.TestCase):
         )
 
         assert logs.output == [
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+            ('INFO:cdflow_commands.logger:ECS service tasks - '
              'desired: 2 pending: 0 running: 0 previous: 0'),
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+            ('INFO:cdflow_commands.logger:ECS service tasks - '
              'desired: 2 pending: 0 running: 1 previous: 0'),
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+            ('INFO:cdflow_commands.logger:ECS service tasks - '
              'desired: 2 pending: 0 running: 2 previous: 0'),
             'INFO:cdflow_commands.logger:Deployment complete'
         ]

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -1,8 +1,9 @@
 import unittest
 import datetime
+from dateutil.tz import tzlocal
 from itertools import cycle, islice
 
-from mock import MagicMock, Mock
+from mock import MagicMock, Mock, ANY
 from hypothesis import given, settings, example
 from hypothesis.strategies import text, fixed_dictionaries
 
@@ -20,7 +21,7 @@ class TestECSMonitor(unittest.TestCase):
     def test_ecs_monitor_successful_deployment(self):
         # Given
         ecs_event_iterator = [
-            DoneEvent(2, 0, 2, 0)
+            DoneEvent(2, 0, 2, 0, [])
         ]
         ecs_monitor = ECSMonitor(ecs_event_iterator)
 
@@ -38,9 +39,9 @@ class TestECSMonitor(unittest.TestCase):
     def test_ecs_monitor_eventual_successful_deployment(self):
         # Given
         ecs_event_iterator = [
-            InProgressEvent(0, 1, 2, 2),
-            InProgressEvent(1, 0, 2, 1),
-            DoneEvent(2, 0, 2, 0)
+            InProgressEvent(0, 1, 2, 2, []),
+            InProgressEvent(1, 0, 2, 1, []),
+            DoneEvent(2, 0, 2, 0, [])
         ]
         ecs_monitor_module.INTERVAL = 0
         ecs_monitor = ECSMonitor(ecs_event_iterator)
@@ -63,8 +64,8 @@ class TestECSMonitor(unittest.TestCase):
     def test_ecs_monitor_deployment_times_out(self):
         # Given
         ecs_event_iterator = cycle([
-            InProgressEvent(0, 0, 2, 0),
-            InProgressEvent(1, 0, 2, 0),
+            InProgressEvent(0, 0, 2, 0, []),
+            InProgressEvent(1, 0, 2, 0, []),
         ])
         ecs_monitor_module.INTERVAL = 0
         ecs_monitor_module.TIMEOUT = 1
@@ -119,6 +120,29 @@ class TestECSEventIterator(unittest.TestCase):
                         }
                     ],
                     'desiredCount': 2,
+                    'events': [
+                        {
+                            'createdAt': datetime.datetime(
+                                2017, 3, 10, 10, 27, 40, 1
+                            ),
+                            'id': '71e1ea54-61bd-4d5f-b6ae-ba0ba4a3c270',
+                            'message': 'has reached a steady state.'
+                        },
+                        {
+                            'createdAt': datetime.datetime(
+                                2017, 3, 9, 16, 26, 49, 794
+                            ),
+                            'id': '851fd578-579d-4a23-8764-107f0cf1120c',
+                            'message': 'registered 1 targets'
+                        },
+                        {
+                            'createdAt': datetime.datetime(
+                                2017, 3, 9, 16, 26, 37, 48000
+                            ),
+                            'id': '39e46d75-018e-4db4-a62d-1d76b4564132',
+                            'message': 'has started 1 tasks'
+                        }
+                    ],
                     'loadBalancers': [
                         {
                             'containerName': 'app',
@@ -174,9 +198,15 @@ class TestECSEventIterator(unittest.TestCase):
 
         event_list = [e for e in events]
 
+        # Then
         assert len(event_list) == 1
         assert event_list[0].done
         assert event_list[0].previous_running == 0
+        assert event_list[0].messages == [
+            'has started 1 tasks',
+            'registered 1 targets',
+            'has reached a steady state.'
+        ]
 
     def test_deployment_completed_after_reaching_desired_running_count(self):
         environment = 'dummy-environment'
@@ -198,6 +228,9 @@ class TestECSEventIterator(unittest.TestCase):
                             'deployments': [
                                 {
                                     'desiredCount': final_running_count,
+                                    'createdAt': datetime.datetime(
+                                        2017, 3, 8, 12, 15, 9, 13000
+                                    ),
                                     'id': 'ecs-svc/9223370553143707624',
                                     'runningCount': running_count,
                                     'pendingCount': pending_count,
@@ -206,6 +239,9 @@ class TestECSEventIterator(unittest.TestCase):
                                 },
                                 {
                                     'desiredCount': final_running_count,
+                                    'createdAt': datetime.datetime(
+                                        2017, 3, 8, 12, 15, 9, 13000
+                                    ),
                                     'id': 'ecs-svc/9223370553143707624',
                                     'pendingCount': 0,
                                     'runningCount': 0,
@@ -303,6 +339,9 @@ class TestECSEventIterator(unittest.TestCase):
                             'deployments': [
                                 {
                                     'desiredCount': initial_running_count,
+                                    'createdAt': datetime.datetime(
+                                        2017, 1, 6, 10, 58, 9
+                                    ),
                                     'id': 'ecs-svc/9223370553143707624',
                                     'runningCount': initial_running_count,
                                     'pendingCount': 0,
@@ -311,6 +350,9 @@ class TestECSEventIterator(unittest.TestCase):
                                 },
                                 {
                                     'desiredCount': initial_running_count,
+                                    'createdAt': datetime.datetime(
+                                        2017, 1, 6, 10, 58, 9
+                                    ),
                                     'id': 'ecs-svc/9223370553143707624',
                                     'pendingCount': 0,
                                     'runningCount': running_count,
@@ -409,6 +451,9 @@ class TestECSEventIterator(unittest.TestCase):
                     'deployments': [
                         {
                             'desiredCount': 2,
+                            'createdAt': datetime.datetime(
+                                2017, 1, 6, 10, 58, 9
+                            ),
                             'id': 'ecs-svc/9223370553143707624',
                             'runningCount': 1,
                             'pendingCount': 1,
@@ -465,6 +510,9 @@ class TestECSEventIterator(unittest.TestCase):
                     'deployments': [
                         {
                             'desiredCount': 2,
+                            u'createdAt': datetime.datetime(
+                                2017, 3, 8, 12, 15, 9, 13000, tzinfo=tzlocal()
+                            ),
                             'id': 'ecs-svc/9223370553143707624',
                             'runningCount': 1,
                             'pendingCount': 1,
@@ -573,6 +621,75 @@ class TestECSEventIterator(unittest.TestCase):
         )
 
         self.assertRaises(ImageDoesNotMatchError, lambda: [e for e in events])
+
+    def test_get_ecs_service_events(self):
+        # Given
+        since = datetime.datetime(
+            2017, 3, 8, 12, 15, 0, 0, tzinfo=tzlocal()
+        )
+        ecs_service_events_1 = [
+            {
+                u'createdAt': datetime.datetime(
+                    2017, 3, 8, 12, 15, 9, 13000, tzinfo=tzlocal()
+                ),
+                u'id': u'efbfce1c-c7d0-43be-a9a8-d18ad70e9d8b',
+                u'message': u'(service aslive-grahamlyons-test) has started 2'
+            },
+            # the event blow should *not* be returned (it's before since)
+            {
+                u'createdAt': datetime.datetime(
+                    2017, 3, 8, 12, 14, 30, 0, tzinfo=tzlocal()
+                ),
+                u'id': u'efbfce1c-c7d0-43be-a9a8-d18ad70e9d8b',
+                u'message': u'old event'
+            }
+        ]
+        ecs_service_events_2 = [
+            {
+                u'createdAt': datetime.datetime(
+                    2017, 3, 8, 12, 15, 46, 32000, tzinfo=tzlocal()
+                ),
+                u'id': u'03c1bf6b-4054-4828-adc0-edce84d96c99',
+                u'message': u'(service aslive-grahamlyons-test) has reached a'
+            },
+            {
+                u'createdAt': datetime.datetime(
+                    2017, 3, 8, 12, 15, 21, 649000, tzinfo=tzlocal()
+                ),
+                u'id': u'66364f80-7713-4260-a8d7-39ec8207f4a9',
+                u'message': u'(service aslive-grahamlyons-test) registered 2 '
+            }
+        ]
+
+        ecs_event_iterator = ECSEventIterator(ANY, ANY, ANY, ANY, ANY)
+
+        # When
+        events_1 = ecs_event_iterator._get_new_ecs_service_events(
+            {
+                'services': [
+                    {
+                        'events': ecs_service_events_1[:1]
+                    }
+                ]
+            }, since
+        )
+        events_2 = ecs_event_iterator._get_new_ecs_service_events(
+            {
+                'services': [
+                    {
+                        'events': ecs_service_events_1[:1]
+                        + ecs_service_events_2
+                    }
+                ]
+            }, since
+        )
+
+        # Then
+        assert events_1 == ecs_service_events_1[:1]
+        assert events_2 == list(reversed(ecs_service_events_2))
+
+        assert events_1 + events_2 == \
+            ecs_service_events_1[:1] + list(reversed(ecs_service_events_2))
 
 
 class TestBuildServiceName(unittest.TestCase):

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -31,7 +31,7 @@ class TestECSMonitor(unittest.TestCase):
 
         # Then
         assert logs.output == [
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks - desired: 2 '
+            ('INFO:cdflow_commands.logger:ECS service tasks - desired: 2 '
              'pending: 0 running: 2 previous: 0'),
             'INFO:cdflow_commands.logger:Deployment complete'
         ]
@@ -52,11 +52,11 @@ class TestECSMonitor(unittest.TestCase):
 
         # Then
         assert logs.output == [
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+            ('INFO:cdflow_commands.logger:ECS service tasks - '
              'desired: 2 pending: 1 running: 0 previous: 2'),
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+            ('INFO:cdflow_commands.logger:ECS service tasks - '
              'desired: 2 pending: 0 running: 1 previous: 1'),
-            ('INFO:cdflow_commands.logger:Deploying ECS tasks - '
+            ('INFO:cdflow_commands.logger:ECS service tasks - '
              'desired: 2 pending: 0 running: 2 previous: 0'),
             'INFO:cdflow_commands.logger:Deployment complete'
         ]

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -704,8 +704,8 @@ class TestECSEventIterator(unittest.TestCase):
             {
                 'services': [
                     {
-                        'events': ecs_service_events_1[:1]
-                        + ecs_service_events_2
+                        'events': ecs_service_events_1[:1] +
+                        ecs_service_events_2
                     }
                 ]
             }, since


### PR DESCRIPTION
During the deploy we'd like to see the ECS server events feed to help us with eventual healthiness problems of tasks.  If cdflow detects any tasks failed health check, deploy should fail immediately.

[1] Example output of successful deploy after this PR
[2] Example output of failed deploy due to failed task health check (after this PR)

[1]
```
State path: .terraform/terraform.tfstate
[terragrunt] 2017/03/10 15:20:37 Attempting to release lock for state file aslive-grahamlyons-test in DynamoDB
[terragrunt] 2017/03/10 15:20:37 Lock released!
[2017-03-10 15:20:38] ECS service tasks - desired: 2 pending: 0 running: 0 previous: 2
[2017-03-10 15:20:53] ECS service event - (service aslive-grahamlyons-test) has started 2 tasks: (task c66a16ed-40a9-4f1c-be05-9f69365ce2bb) (task 5106b2a0-2963-49ba-996e-4112ede89683).
[2017-03-10 15:20:53] ECS service tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-10 15:21:08] ECS service event - (service aslive-grahamlyons-test) registered 2 targets in (target-group arn:aws:elasticloadbalancing:eu-west-1:733578946173:targetgroup/aslive-grahamlyons-test/7ec99a6cf35af5c6)
[2017-03-10 15:21:08] ECS service tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-10 15:21:23] ECS service event - (service aslive-grahamlyons-test) deregistered 2 targets in (target-group arn:aws:elasticloadbalancing:eu-west-1:733578946173:targetgroup/aslive-grahamlyons-test/7ec99a6cf35af5c6)
[2017-03-10 15:21:23] ECS service event - (service aslive-grahamlyons-test) has begun draining connections on 2 tasks.
[2017-03-10 15:21:23] ECS service tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-10 15:21:38] ECS service tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-10 15:21:53] ECS service event - (service aslive-grahamlyons-test) has stopped 2 running tasks: (task 52762b96-e2a9-46ab-b24c-2b2e37f75ca5) (task 2a75c08b-2454-4bcc-90e4-74f1074d58a8).
[2017-03-10 15:21:53] ECS service tasks - desired: 2 pending: 0 running: 2 previous: 0
[2017-03-10 15:21:53] Deployment complete
```
[2] 
```
[terragrunt] 2017/03/10 17:44:37 Attempting to release lock for state file aslive-grahamlyons-test in DynamoDB
[terragrunt] 2017/03/10 17:44:37 Lock released!
[2017-03-10 17:44:37] ECS service tasks - desired: 2 pending: 0 running: 0 previous: 2
[2017-03-10 17:44:52] ECS service event - (service aslive-grahamlyons-test) has started 2 tasks: (task 3a718207-5b4e-4bcd-972c-921b00139c51) (task 8fc9b829-6d0b-4fd1-8d52-273fc40e4
b9d).
[2017-03-10 17:44:52] ECS service tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-10 17:45:08] ECS service event - (service aslive-grahamlyons-test) registered 2 targets in (target-group arn:aws:elasticloadbalancing:eu-west-1:733578946173:targetgroup/as
live-grahamlyons-test/7ec99a6cf35af5c6)
[2017-03-10 17:45:08] ECS service tasks - desired: 2 pending: 0 running: 2 previous: 2
[2017-03-10 17:45:23] ECS service event - (service aslive-grahamlyons-test) (instance i-0104b2f421bc9ebbe) (port 32771) is unhealthy in (target-group arn:aws:elasticloadbalancing:e
u-west-1:733578946173:targetgroup/aslive-grahamlyons-test/7ec99a6cf35af5c6) due to (reason Health checks failed)
[2017-03-10 17:45:23] ECS service event - (service aslive-grahamlyons-test) (instance i-038aea39f97791747) (port 32771) is unhealthy in (target-group arn:aws:elasticloadbalancing:e
u-west-1:733578946173:targetgroup/aslive-grahamlyons-test/7ec99a6cf35af5c6) due to (reason Health checks failed)
[2017-03-10 17:45:23] ECS service event - (service aslive-grahamlyons-test) deregistered 2 targets in (target-group arn:aws:elasticloadbalancing:eu-west-1:733578946173:targetgroup/
aslive-grahamlyons-test/7ec99a6cf35af5c6)
[2017-03-10 17:45:23] ECS service event - (service aslive-grahamlyons-test) has stopped 2 running tasks: (task 8fc9b829-6d0b-4fd1-8d52-273fc40e4b9d) (task 3a718207-5b4e-4bcd-972c-9
21b00139c51).
[2017-03-10 17:45:23] ECS service event - (service aslive-grahamlyons-test) deregistered 1 targets in (target-group arn:aws:elasticloadbalancing:eu-west-1:733578946173:targetgroup/
aslive-grahamlyons-test/7ec99a6cf35af5c6)
[2017-03-10 17:45:23] ECS service tasks - desired: 2 pending: 0 running: 0 previous: 2
[2017-03-10 17:45:23] Deployment failed - tasks (containers) are failing to pass healthcheck
```