### PR TITLE
Reworks the exception hierarchy for the project

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -33,7 +33,7 @@ from cdflow_commands.release import Release, ReleaseConfig
 from cdflow_commands.deploy import Deploy, DeployConfig
 from cdflow_commands.destroy import Destroy
 from cdflow_commands.ecs_monitor import ECSEventIterator, ECSMonitor
-from cdflow_commands.exceptions import UserError
+from cdflow_commands.exceptions import UserFacingError
 from cdflow_commands.logger import logger
 from cdflow_commands.terragrunt import S3BucketFactory, write_terragrunt_config
 
@@ -41,7 +41,7 @@ from cdflow_commands.terragrunt import S3BucketFactory, write_terragrunt_config
 def run(argv):
     try:
         _run(argv)
-    except UserError as err:
+    except UserFacingError as err:
         logger.error(err)
         sys.exit(1)
     finally:

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -5,25 +5,27 @@ from subprocess import check_output, CalledProcessError
 
 from boto3.session import Session
 
-from cdflow_commands.exceptions import UserError
+from cdflow_commands.exceptions import (
+    UserFacingError, UserFacingFixedMessageError
+)
 
 
 PLATFORM_CONFIG_PATH_TEMPLATE = 'infra/platform-config/{}/{}/{}.json'
 
 
-class JobNameTooShortError(UserError):
-    _message = 'JOB_NAME must be at least 6 characters'
+class JobNameTooShortError(UserFacingError):
+    pass
 
 
-class InvalidEmailError(UserError):
-    _message = 'EMAIL does not contain a valid email address'
+class InvalidEmailError(UserFacingError):
+    pass
 
 
-class NoJobNameOrEmailError(UserError):
+class NoJobNameOrEmailError(UserFacingFixedMessageError):
     _message = 'JOB_NAME or EMAIL must be set'
 
 
-class NoGitRemoteError(UserError):
+class NoGitRemoteError(UserFacingFixedMessageError):
     _message = 'No git remote configured - cannot infer component name'
 
 
@@ -84,12 +86,16 @@ def assume_role(root_session, acccount_id, session_name):
 
 def _validate_job_name(job_name):
     if len(job_name) < 6:
-        raise JobNameTooShortError()
+        raise JobNameTooShortError(
+            'JOB_NAME must be at least 6 characters', job_name
+        )
 
 
 def _validate_email(email):
     if not match(r'.+@([\w-]+\.)+\w+$', email, DOTALL):
-        raise InvalidEmailError()
+        raise InvalidEmailError(
+            'EMAIL does not contain a valid email address', email
+        )
 
 
 def get_role_session_name(env):

--- a/cdflow_commands/exceptions.py
+++ b/cdflow_commands/exceptions.py
@@ -1,5 +1,17 @@
-class UserError(Exception):
-    _message = 'User error'
+class CDFlowError(Exception):
+    pass
+
+
+class UserFacingError(CDFlowError):
+    pass
+
+
+class FixedMessageError(CDFlowError):
+    _message = 'Error'
 
     def __str__(self):
         return self._message
+
+
+class UserFacingFixedMessageError(UserFacingError, FixedMessageError):
+    pass

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,7 +16,7 @@ from cdflow_commands import cli
 from cdflow_commands.ecs_monitor import (
     InProgressEvent, DoneEvent
 )
-from cdflow_commands.exceptions import UserError
+from cdflow_commands.exceptions import UserFacingError
 
 
 @patch('cdflow_commands.cli.rmtree')
@@ -618,7 +618,7 @@ class TestVerboseLogging(unittest.TestCase):
         self, load_service_metadata, _1, _2, _3
     ):
         # Given
-        load_service_metadata.side_effect = UserError
+        load_service_metadata.side_effect = UserFacingError
 
         # When
         with self.assertLogs('cdflow_commands.logger', level='DEBUG') as logs:
@@ -631,7 +631,7 @@ class TestVerboseLogging(unittest.TestCase):
         self, load_service_metadata, _1, _2, _3
     ):
         # Given
-        load_service_metadata.side_effect = UserError
+        load_service_metadata.side_effect = UserFacingError
 
         # When
         with self.assertLogs('cdflow_commands.logger', level='DEBUG') as logs:
@@ -645,13 +645,13 @@ class TestVerboseLogging(unittest.TestCase):
 @patch('cdflow_commands.cli.unlink')
 @patch('cdflow_commands.cli.sys')
 @patch('cdflow_commands.cli.load_service_metadata')
-class TestUserErrorThrown(unittest.TestCase):
+class TestUserFacingErrorThrown(unittest.TestCase):
 
     def test_non_zero_exit(
         self, load_service_metadata, mock_sys, _1, _2
     ):
         # Given
-        load_service_metadata.side_effect = UserError
+        load_service_metadata.side_effect = UserFacingError('Error')
 
         # When
         with self.assertLogs('cdflow_commands.logger', level='ERROR') as logs:
@@ -659,14 +659,14 @@ class TestUserErrorThrown(unittest.TestCase):
 
         # Then
         mock_sys.exit.assert_called_once_with(1)
-        expected_message = 'ERROR:cdflow_commands.logger:User error'
+        expected_message = 'ERROR:cdflow_commands.logger:Error'
         assert expected_message in logs.output
 
     def test_files_are_always_attempted_to_be_removed(
         self, load_service_metadata, mock_sys, unlink, rmtree
     ):
         # Given
-        load_service_metadata.side_effect = UserError
+        load_service_metadata.side_effect = UserFacingError
 
         # When
         cli.run(['release', 'version'])
@@ -679,7 +679,7 @@ class TestUserErrorThrown(unittest.TestCase):
         self, load_service_metadata, mock_sys, unlink, rmtree
     ):
         # Given
-        load_service_metadata.side_effect = UserError
+        load_service_metadata.side_effect = UserFacingError
         unlink.side_effect = OSError
         rmtree.side_effect = OSError
 

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -649,6 +649,12 @@ class TestECSEventIterator(unittest.TestCase):
 
         self.assertRaises(ImageDoesNotMatchError, lambda: [e for e in events])
 
+        try:
+            next(iter(events))
+        except ImageDoesNotMatchError as e:
+            assert 'none' in str(e)
+            assert '{}:{}'.format(component, version) in str(e)
+
     def test_get_ecs_service_events(self):
         # Given
         since = datetime.datetime(


### PR DESCRIPTION
We had only a `UserError` as an exception parent, which was meant for
exceptions to be displayed to the user. It used a fixed string message
which wasn't always appropriate.

This introduces a `CDFlowError` at the top level and has `UserFacingError`
and `FixedMessageError` inheriting from that - `UserFacingFixedMessageError`
inherits from both of those:

```
                CDFlowError
                     |
UserFacingError             FixedMessageError
                \          /
          UserFacingFixedMessageError
```

JIRA: PLAT-848