### PR TITLE
PLAT-836 - Deploy always completes when deploying a new service

### DIFF
--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -152,8 +152,8 @@ class ECSEventIterator():
 
     def _assert_correct_image_being_deployed(self, task_definition):
         release_image = self._get_release_image(task_definition)
-
         requested_image = '{}:{}'.format(self._component, self._version)
+
         if release_image != requested_image:
             raise ImageDoesNotMatchError(
                 'Requested image {} does not match image '

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -10,7 +10,6 @@ from cdflow_commands.exceptions import (
 
 TIMEOUT = 600
 INTERVAL = 15
-NEW_SERVICE_DEPLOYMENT_GRACE_PERIOD_LIMIT = 4
 
 
 def build_service_name(environment, component):
@@ -75,7 +74,7 @@ class ECSEventIterator():
         self._done = False
         self._seen_ecs_service_events = set()
         self._new_service_deployment = None
-        self._new_service_deployment_grace_period_count = 0
+        self._new_service_grace_period = 60
 
     def __iter__(self):
         return self
@@ -126,9 +125,8 @@ class ECSEventIterator():
         if running != desired or previous_running:
             return True
         elif (running == desired and self._new_service_deployment and
-                self._new_service_deployment_grace_period_count <
-                NEW_SERVICE_DEPLOYMENT_GRACE_PERIOD_LIMIT):
-            self._new_service_deployment_grace_period_count += 1
+                self._new_service_grace_period > 0):
+            self._new_service_grace_period -= INTERVAL
             return True
 
         return False

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -112,7 +112,7 @@ class ECSEventIterator():
             primary_deployment
         )
 
-        if self._deploy_in_progres(running, desired, previous_running):
+        if self._deploy_in_progress(running, desired, previous_running):
             return InProgressEvent(
                 running, pending, desired, previous_running, messages
             )

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -122,11 +122,8 @@ class ECSEventIterator():
             running, pending, desired, previous_running, messages
         )
 
-    def _deploy_in_progres(self, running, desired, previous_running):
-        if (
-            running != desired or
-            previous_running
-        ):
+    def _deploy_in_progress(self, running, desired, previous_running):
+        if running != desired or previous_running:
             return True
         elif (running == desired and self._new_service_deployment and
                 self._new_service_deployment_grace_period_count <

--- a/cdflow_commands/ecs_monitor.py
+++ b/cdflow_commands/ecs_monitor.py
@@ -91,7 +91,8 @@ class ECSEventIterator():
 
         deployments = self._get_deployments(ecs_service_data)
         primary_deployment = self._get_primary_deployment(deployments)
-        release_image = self._get_release_image(
+
+        self._assert_correct_image_being_deployed(
             primary_deployment['taskDefinition']
         )
 
@@ -151,6 +152,17 @@ class ECSEventIterator():
 
         return task_def['image'].split('/', 1)[1]
 
+    def _assert_correct_image_being_deployed(self, task_definition):
+        release_image = self._get_release_image(task_definition)
+
+        requested_image = '{}:{}'.format(self._component, self._version)
+        if release_image != requested_image:
+            raise ImageDoesNotMatchError(
+                'Requested image {} does not match image '
+                'found in deployment {}'.format(
+                    requested_image, release_image
+                )
+            )
     def _get_deployments(self, ecs_service_data):
         return [
             deployment

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -144,7 +144,7 @@ class TestECSEventIterator(unittest.TestCase):
                             'status': 'PRIMARY',
                             'taskDefinition': task_definition_arn,
                             'updatedAt': datetime.datetime(2017, 1, 6, 13, 57)
-                        }
+                        },
                     ],
                     'desiredCount': 2,
                     'events': [

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -737,7 +737,6 @@ class TestECSEventIterator(unittest.TestCase):
         events = ECSEventIterator(
             cluster, environment, component, version, boto_session
         )
-
         event_list = [e for e in events]
 
         assert len(event_list) == 8

--- a/test/test_ecs_monitor.py
+++ b/test/test_ecs_monitor.py
@@ -611,7 +611,8 @@ class TestECSEventIterator(unittest.TestCase):
                             'runningCount': 2,
                             'status': 'PRIMARY',
                             'taskDefinition': task_definition_arn,
-                            'updatedAt': datetime.datetime(2017, 1, 6, 13, 57)
+                            'updatedAt': datetime.datetime(2017, 1, 6, 13, 57),
+                            'createdAt': datetime.datetime(2017, 1, 6, 13, 57)
                         }
                     ],
                     'status': 'ACTIVE',


### PR DESCRIPTION
Previously, deploy would always succeed when we were deploying a new service, even, if the new server would go into unhealthy state right after.  This was happening due to lack of previously running tasks during deploy for new service and deployment finished condition was being met as soon as running tasks number equaled desired tasks number.

This PR introduces additional wait time (healthcheck grace period time) which is executed when we're deploying a new service.