### PR TITLE
Fix not able to get component name with trailing /

### DIFF
--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -120,7 +120,7 @@ def _get_component_name_from_git_remote():
         remote = check_output(['git', 'config', 'remote.origin.url'])
     except CalledProcessError:
         raise NoGitRemoteError()
-    name = remote.decode('utf-8').strip().split('/')[-1]
+    name = remote.decode('utf-8').strip("\t\n /").split('/')[-1]
     if name.endswith('.git'):
         return name[:-4]
     return name

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -293,6 +293,20 @@ class TestGetComponentName(unittest.TestCase):
     @given(text(
         alphabet=ascii_letters + digits + '-._', min_size=1, max_size=100
     ))
+    def test_component_not_passed_as_argument_with_backslash(
+        self, component_name
+    ):
+        with patch('cdflow_commands.config.check_output') as check_output:
+            check_output.return_value = 'git@github.com:org/{}/\n'.format(
+                component_name
+            ).encode('utf-8')
+            extraced_component_name = config.get_component_name(None)
+
+            assert extraced_component_name == component_name
+
+    @given(text(
+        alphabet=ascii_letters + digits + '-._', min_size=1, max_size=100
+    ))
     def test_component_not_passed_as_argument_with_https_origin(
         self, component_name
     ):


### PR DESCRIPTION
What?
-----

If the git repository setup as remote url contains a trailing url,
cdflow would fail extracting the component name.

To fix it, we must also trim the `/`

How to test?
------------

A test has been added, run `./test.sh`

Who?
----

Anyone but @keymon