### PR TITLE
[PLAT-865] More friendly message for incomplete service.json

### DIFF
--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -44,13 +44,18 @@ GlobalConfig = namedtuple(
 def load_service_metadata():
     with open('service.json') as f:
         metadata = json.loads(f.read())
-        return Metadata(
-            metadata['TEAM'],
-            metadata['TYPE'],
-            metadata['REGION'],
-            metadata['ACCOUNT_PREFIX'],
-            metadata.get('ECS_CLUSTER', 'default')
-        )
+        try:
+            return Metadata(
+                metadata['TEAM'],
+                metadata['TYPE'],
+                metadata['REGION'],
+                metadata['ACCOUNT_PREFIX'],
+                metadata.get('ECS_CLUSTER', 'default')
+            )
+        except KeyError as key:
+            raise UserFacingError(
+                    "Deployment failed - did you set {} in {}?".format(
+                        key, f.name))
 
 
 def load_global_config(account_prefix, aws_region):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -54,8 +54,10 @@ class TestLoadConfig(unittest.TestCase):
         }
         mock_file.read.return_value = json.dumps(expected_config)
         mock_open.return_value.__enter__.return_value = mock_file
-        with self.assertRaisesRegexp(UserFacingError,
-                'Deployment failed - did you set .* in .*'):
+        with self.assertRaisesRegexp(
+            UserFacingError,
+            'Deployment failed - did you set .* in .*'
+        ):
             config.load_service_metadata()
 
     @patch('cdflow_commands.config.open', new_callable=mock_open, create=True)


### PR DESCRIPTION
https://workflow.mergermarket.com/browse/PLAT-865

What?
----

As platform engineer I want to make the missing metadata errors in CDFlow
more user friendly, eg. if we don't specify REGION in service.json,
I want to see a user-friendly message like
"Deployment failed - did you set REGION in service.json?"

How to review?
--------------

Code review. Run the test with: `./test.sh -k test_service_metadata_user_facing_error`

Who?
----

Anyone but @keymon

PLAT-865