### PR TITLE
Include environment config for infrastructure

### DIFF
--- a/cdflow_commands/plugins/infrastructure.py
+++ b/cdflow_commands/plugins/infrastructure.py
@@ -2,6 +2,7 @@ import json
 import os
 from collections import namedtuple
 from itertools import chain
+from os import path
 from subprocess import check_call
 from tempfile import NamedTemporaryFile
 
@@ -123,6 +124,10 @@ class Deploy:
             '-var-file', self._config.platform_config_file,
             '-var-file', secrets_file
         ]
+
+        config_file = 'config/{}.json'.format(self._environment_name)
+        if path.exists(config_file):
+            parameters += ['-var-file', config_file]
 
         additional_variables = chain.from_iterable(
             ('-var', variable) for variable in self._additional_variables


### PR DESCRIPTION
When using infrastructure only projects, we still want to include environment specific configs (we seem to have forgot about it when adding infrastructure plugin)