### PR TITLE
Throw exception when required arguments are missing

### DIFF
--- a/cdflow_commands/exceptions.py
+++ b/cdflow_commands/exceptions.py
@@ -6,6 +6,10 @@ class UserFacingError(CDFlowError):
     pass
 
 
+class MissingArgumentError(UserFacingError):
+    pass
+
+
 class FixedMessageError(CDFlowError):
     _message = 'Error'
 

--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -14,7 +14,7 @@ from cdflow_commands.config import (
     assume_role, get_platform_config_path, get_role_session_name
 )
 from cdflow_commands.exceptions import (
-    UserFacingError, UserFacingFixedMessageError
+    UserFacingError, UserFacingFixedMessageError, MissingArgumentError
 )
 from cdflow_commands.logger import logger
 from cdflow_commands.plugins import Plugin
@@ -29,6 +29,8 @@ def build_ecs_plugin(
     environment_name, component_name, version,
     metadata, global_config, root_session
 ):
+    validate_plugin_arguments(environment_name, version)
+
     release_factory = build_release_factory(
         component_name, version, metadata, global_config, root_session
     )
@@ -53,6 +55,14 @@ def build_ecs_plugin(
         destroy_factory,
         deploy_monitor_factory
     )
+
+
+def validate_plugin_arguments(environment_name, version):
+    if environment_name == '':
+        raise MissingArgumentError('Environment is missing')
+
+    if version == '':
+        raise MissingArgumentError('Version is missing')
 
 
 def build_release_factory(

--- a/cdflow_commands/plugins/infrastructure.py
+++ b/cdflow_commands/plugins/infrastructure.py
@@ -9,6 +9,7 @@ from tempfile import NamedTemporaryFile
 from cdflow_commands.config import (
     assume_role, get_platform_config_path, get_role_session_name
 )
+from cdflow_commands.exceptions import MissingArgumentError
 from cdflow_commands.logger import logger
 from cdflow_commands.plugins import Plugin
 from cdflow_commands.plugins.base import Destroy
@@ -27,7 +28,7 @@ def build_infrastructure_plugin(
     environment_name, component_name, additional_variables,
     metadata, global_config, root_session
 ):
-
+    validate_plugin_arguments(environment_name)
     release_factory = None
 
     deploy_factory = build_deploy_factory(
@@ -42,6 +43,11 @@ def build_infrastructure_plugin(
     return InfrastructurePlugin(
         release_factory, deploy_factory, destroy_factory
     )
+
+
+def validate_plugin_arguments(environment_name):
+    if environment_name == '':
+        raise MissingArgumentError('Environment is missing')
 
 
 def build_deploy_factory(

--- a/test/plugins/test_ecs.py
+++ b/test/plugins/test_ecs.py
@@ -1,6 +1,7 @@
 import unittest
 
-from cdflow_commands.plugins.ecs import ECSPlugin
+from cdflow_commands.exceptions import MissingArgumentError
+from cdflow_commands.plugins.ecs import ECSPlugin, build_ecs_plugin
 from mock import ANY, Mock
 
 
@@ -83,3 +84,19 @@ class TestECSPlugin(unittest.TestCase):
 
         # Then
         deploy_monitor.wait.assert_called_once()
+
+    def test_plugin_fails_to_build_when_version_missing(self):
+        # Given
+        version = ''
+
+        # Then
+        with self.assertRaises(MissingArgumentError):
+            build_ecs_plugin(ANY, ANY, version, ANY, ANY, ANY)
+
+    def test_plugin_fails_to_build_when_environment_missing(self):
+        # Given
+        environment = ''
+
+        # Then
+        with self.assertRaises(MissingArgumentError):
+            build_ecs_plugin(environment, ANY, ANY, ANY, ANY, ANY)

--- a/test/plugins/test_infrastructure.py
+++ b/test/plugins/test_infrastructure.py
@@ -1,6 +1,9 @@
 import unittest
 
-from cdflow_commands.plugins.infrastructure import InfrastructurePlugin
+from cdflow_commands.exceptions import MissingArgumentError
+from cdflow_commands.plugins.infrastructure import (
+    InfrastructurePlugin, build_infrastructure_plugin
+)
 from mock import ANY, Mock
 
 
@@ -57,3 +60,11 @@ class TestInfrastructurePlugin(unittest.TestCase):
 
         # Then
         destroy.run.assert_called_once()
+
+    def test_plugin_fails_to_build_when_environment_missing(self):
+        # Given
+        environment = ''
+
+        # Then
+        with self.assertRaises(MissingArgumentError):
+            build_infrastructure_plugin(environment, ANY, ANY, ANY, ANY, ANY)


### PR DESCRIPTION
We want CDFlow to throw an exception and fail a deployment as soon as any of the required arguments is missing.

We implement it within plugins, as different plugins have different arguments required to work (eg. version is needed by ECS deploy but not by infrastructure)

JIRA: PLAT-887