### PR TITLE
Update container to run Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,10 @@
-FROM python:3
+FROM python:3-alpine
 
-ENV TERRAFORM_VERSION=0.9.2
+ENV TERRAFORM_VERSION=0.9.4
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-     apt-transport-https \
-     ca-certificates \
-     curl \
-     software-properties-common \
-     unzip && \
-    curl -fsSL https://apt.dockerproject.org/gpg | apt-key add - && \
-    add-apt-repository "deb https://apt.dockerproject.org/repo/ \
-       debian-$(lsb_release -cs) \
-       main" && \
-    apt-get update && apt-get -y install docker-engine && \
-    apt-get clean
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories
+RUN apk update
+RUN apk add gcc musl-dev libffi-dev openssl-dev docker curl git
 
 RUN cd /tmp && \
     curl -sSLO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,10 @@
-FROM python:3
+FROM python:3-alpine
 
 RUN mkdir /cdflow
 WORKDIR /cdflow
+
+RUN apk update
+RUN apk add gcc musl-dev libffi-dev openssl-dev
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
The Debian-based Python image is more than twice as large as the one based on Alpine Linux so it would be nicer for users not to wait so long to pull our image down.