### PR TITLE
Adding logging around the release of Lambda

### DIFF
--- a/cdflow_commands/plugins/aws_lambda.py
+++ b/cdflow_commands/plugins/aws_lambda.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 from cdflow_commands.config import (
     assume_role, get_role_session_name, get_platform_config_path
 )
+from cdflow_commands.logger import logger
 from cdflow_commands.plugins import Plugin
 from cdflow_commands.secrets import get_secrets
 from cdflow_commands.state import (
@@ -172,6 +173,7 @@ class Release():
         self._remove_zipped_folder(zipped_folder.filename)
 
     def _zip_up_component(self):
+        logger.info('Zipping up ./{} folder'.format(self._component_name))
         with ZipFile(self._component_name + '.zip', 'w') as zipped_folder:
             for dirname, subdirs, files in os.walk(self._component_name):
                 zipped_folder.write(dirname)
@@ -180,6 +182,9 @@ class Release():
         return zipped_folder
 
     def _upload_zip_to_bucket(self, boto_s3_client, bucket_name, filename):
+        logger.info('Uploading {} to s3 bucket ({}) with key: {}'.format(
+            filename, bucket_name, self._lambda_s3_key
+        ))
         boto_s3_client.upload_file(
             filename,
             bucket_name,
@@ -187,6 +192,7 @@ class Release():
         )
 
     def _remove_zipped_folder(self, filename):
+        logger.info('Removing local zipped package: {}'.format(filename))
         os.remove(filename)
 
 

--- a/cdflow_commands/state.py
+++ b/cdflow_commands/state.py
@@ -164,6 +164,11 @@ class S3BucketFactory(object):
         '''.format(bucket_tag, TAG_VALUE).strip()
 
         if len(tagged_buckets) == 1:
+            logger.debug(
+                'Single bucket ({}) with tag: {}={} found'.format(
+                    list(tagged_buckets)[0], bucket_tag, TAG_VALUE
+                )
+            )
             return list(tagged_buckets)[0]
         else:
             bucket_name = self._create_bucket(bucket_name_prefix)
@@ -197,6 +202,7 @@ class S3BucketFactory(object):
         return {tag['Key']: tag['Value'] for tag in tags}
 
     def _create_bucket(self, bucket_name_prefix):
+        logger.debug('Creating bucket with name {}'.format(bucket_name_prefix))
         for attempt in range(MAX_CREATION_ATTEMPTS):
             if bucket_name_prefix == TFSTATE_NAME_PREFIX:
                 bucket_name = self._generate_bucket_name(
@@ -205,6 +211,9 @@ class S3BucketFactory(object):
             else:
                 bucket_name = LAMBDA_BUCKET_NAME
             if self._attempt_to_create_bucket(bucket_name):
+                logger.debug(
+                    's3 bucket with name: {} created'.format(bucket_name)
+                )
                 return bucket_name
         raise Exception('could not create bucket after {} attempts'.format(
             MAX_CREATION_ATTEMPTS
@@ -235,6 +244,9 @@ class S3BucketFactory(object):
         return True
 
     def _tag_bucket(self, bucket_name, bucket_tag):
+        logger.debug('Tagging bucket: {} with tag: {}={}'.format(
+            bucket_name, bucket_tag, TAG_VALUE
+        ))
         self._boto_s3_client.put_bucket_tagging(
             Bucket=bucket_name,
             Tagging={


### PR DESCRIPTION
When we run a release of a lambda project, we do a lot of work in the
background that isn't really exposed to the user so they get no feedback
when things go as expected. We've added logging to show whats going on
including some debug messages around the s3 bucket creation and tagging.

JIRA:PLAT-924