### PR TITLE
Changing the way we zip up the lambda

### DIFF
--- a/cdflow_commands/plugins/aws_lambda.py
+++ b/cdflow_commands/plugins/aws_lambda.py
@@ -174,11 +174,13 @@ class Release():
 
     def _zip_up_component(self):
         logger.info('Zipping up ./{} folder'.format(self._component_name))
+        top_level = os.getcwd()
         with ZipFile(self._component_name + '.zip', 'w') as zipped_folder:
             for dirname, subdirs, files in os.walk(self._component_name):
-                zipped_folder.write(dirname)
+                os.chdir(dirname)
                 for filename in files:
-                    zipped_folder.write(os.path.join(dirname, filename))
+                    zipped_folder.write(filename)
+                os.chdir(top_level)
         return zipped_folder
 
     def _upload_zip_to_bucket(self, boto_s3_client, bucket_name, filename):

--- a/cdflow_commands/plugins/aws_lambda.py
+++ b/cdflow_commands/plugins/aws_lambda.py
@@ -183,10 +183,10 @@ class Release():
     def _zip_up_component(self):
         logger.info('Zipping up ./{} folder'.format(self._component_name))
         with ZipFile(self._component_name + '.zip', 'w') as zipped_folder:
-            for dirname, subdirs, files in os.walk(self._component_name):
-                with self._change_dir(dirname):
+            with self._change_dir(self._component_name):
+                for dirname, subdirs, files in os.walk('.'):
                     for filename in files:
-                        zipped_folder.write(filename)
+                        zipped_folder.write(os.path.join(dirname, filename))
         return zipped_folder
 
     def _upload_zip_to_bucket(self, boto_s3_client, bucket_name, filename):


### PR DESCRIPTION
If you have a top level directory in the zip file with the lambda
function in it, you can't edit the function in line on the aws console.
Here we're zipping the lambda handler file directly to the top level.

JIRA: PLAT-915