### PR TITLE
Added plan flag for infrastructure deploy

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -10,7 +10,7 @@ Usage:
 Options:
     -c <component_name>, --component <component_name>
     -v, --verbose
-    -p, --plan
+    -p, --plan-only
 
 """
 import logging
@@ -62,7 +62,7 @@ def _run(argv):
         metadata=metadata,
         global_config=global_config,
         root_session=root_session,
-        plan_only=args['--plan']
+        plan_only=args['--plan-only']
     )
 
     if args['release']:

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -10,6 +10,7 @@ Usage:
 Options:
     -c <component_name>, --component <component_name>
     -v, --verbose
+    -p, --plan
 
 """
 import logging
@@ -61,6 +62,7 @@ def _run(argv):
         metadata=metadata,
         global_config=global_config,
         root_session=root_session,
+        plan_only=args['--plan']
     )
 
     if args['release']:
@@ -89,6 +91,7 @@ def build_plugin(project_type, **kwargs):
             kwargs['metadata'],
             kwargs['global_config'],
             kwargs['root_session'],
+            kwargs['plan_only']
         )
     elif project_type == 'lambda':
         plugin = build_lambda_plugin(

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -101,6 +101,7 @@ def build_plugin(project_type, **kwargs):
             kwargs['metadata'],
             kwargs['global_config'],
             kwargs['root_session'],
+            kwargs['plan_only']
         )
     return plugin
 

--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -156,7 +156,7 @@ def build_destroy_factory(
         )
 
         return Destroy(
-            boto_session, component_name, environment_name, s3_bucket
+            boto_session, component_name, environment_name, s3_bucket, False
         )
     return _destroy_factory
 

--- a/cdflow_commands/plugins/infrastructure.py
+++ b/cdflow_commands/plugins/infrastructure.py
@@ -37,7 +37,8 @@ def build_infrastructure_plugin(
     )
 
     destroy_factory = build_destroy_factory(
-        environment_name, component_name, metadata, global_config, root_session
+        environment_name, component_name, metadata,
+        global_config, root_session, plan_only
     )
 
     return InfrastructurePlugin(
@@ -92,7 +93,8 @@ def build_deploy_factory(
 
 
 def build_destroy_factory(
-    environment_name, component_name, metadata, global_config, root_session
+    environment_name, component_name, metadata,
+    global_config, root_session, plan_only
 ):
     def _destroy_factory():
         is_prod = environment_name == 'live'
@@ -119,7 +121,11 @@ def build_destroy_factory(
         )
 
         return Destroy(
-            boto_session, component_name, environment_name, s3_bucket
+            boto_session,
+            component_name,
+            environment_name,
+            s3_bucket,
+            plan_only
         )
     return _destroy_factory
 

--- a/test/plugins/test_base_destroy.py
+++ b/test/plugins/test_base_destroy.py
@@ -26,7 +26,11 @@ class TestDestroy(unittest.TestCase):
         boto_session = Mock()
         boto_session.region_name = test_fixtures['region']
         destroy = Destroy(
-            boto_session, component_name, environment_name, 'dummy-bucket'
+            boto_session,
+            component_name,
+            environment_name,
+            'dummy-bucket',
+            False
         )
 
         with patch('cdflow_commands.plugins.base.check_call') as check_call:
@@ -48,7 +52,11 @@ class TestDestroy(unittest.TestCase):
         boto_session = Mock()
         boto_session.region_name = test_fixtures['region']
         destroy = Destroy(
-            boto_session, component_name, environment_name, 'dummy-bucket'
+            boto_session,
+            component_name,
+            environment_name,
+            'dummy-bucket',
+            False
         )
 
         with patch('cdflow_commands.plugins.base.check_call') as check_call:
@@ -73,8 +81,11 @@ class TestDestroy(unittest.TestCase):
             aws_config['session_token'],
         )
         destroy = Destroy(
-            boto_session, 'dummy-component',
-            'dummy-environment', 'dummy-bucket'
+            boto_session,
+            'dummy-component',
+            'dummy-environment',
+            'dummy-bucket',
+            False
         )
 
         with patch('cdflow_commands.plugins.base.check_call') as check_call:
@@ -104,8 +115,11 @@ class TestDestroy(unittest.TestCase):
             'dummy-session-token',
         )
         destroy = Destroy(
-            boto_session, 'dummy-component',
-            'dummy-environment', 'dummy-bucket'
+            boto_session,
+            'dummy-component',
+            'dummy-environment',
+            'dummy-bucket',
+            False
         )
 
         with patch(
@@ -144,7 +158,8 @@ class TestDestroy(unittest.TestCase):
             boto_session,
             test_fixtures['component_name'],
             test_fixtures['environment_name'],
-            test_fixtures['s3_bucket_name']
+            test_fixtures['s3_bucket_name'],
+            False
         )
 
         # When

--- a/test/plugins/test_lambda_deploy.py
+++ b/test/plugins/test_lambda_deploy.py
@@ -30,7 +30,7 @@ class TestDeploy(unittest.TestCase):
         )
         self._deploy = Deploy(
             boto_session, 'dummy-component', 'dummy-env', 'dummy-version',
-            self._deploy_config, self._lambda_config
+            self._deploy_config, self._lambda_config, False
         )
 
     @patch('cdflow_commands.plugins.aws_lambda.check_call')
@@ -99,7 +99,7 @@ class TestDeploy(unittest.TestCase):
         )
         deploy = Deploy(
             boto_session, ANY, ANY, ANY, self._deploy_config,
-            self._lambda_config
+            self._lambda_config, False
         )
 
         with patch(
@@ -157,7 +157,7 @@ class TestDeploy(unittest.TestCase):
 
         deploy = Deploy(
             boto_session, ANY, ANY, ANY, self._deploy_config,
-            self._lambda_config
+            self._lambda_config, False
         )
 
         with patch(
@@ -208,7 +208,7 @@ class TestDeploy(unittest.TestCase):
 
         deploy = Deploy(
             boto_session, ANY, ANY, ANY, self._deploy_config,
-            self._lambda_config
+            self._lambda_config, False
         )
 
         with patch(
@@ -267,7 +267,8 @@ class TestDeploy(unittest.TestCase):
             data['environment_name'],
             data['version'],
             deploy_config,
-            lambda_config
+            lambda_config,
+            False
         )
 
         secret_file_path = '/mock/file/path'
@@ -329,7 +330,7 @@ class TestEnvironmentSpecificConfigAddedToTerraformArgs(unittest.TestCase):
         )
         deploy = Deploy(
             boto_session, 'dummy-component', env_name,
-            'dummy-version', deploy_config, lambda_config
+            'dummy-version', deploy_config, lambda_config, False
         )
 
         # When

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -267,6 +267,64 @@ class TestDeployCLI(unittest.TestCase):
             }
         )
 
+    def test_deploy_is_planned_with_flag(self):
+        # Given
+
+        # When
+        cli.run([
+            'deploy', 'aslive',
+            '--var', 'raindrops=roses',
+            '--var', 'whiskers=kittens',
+            '--plan'
+        ])
+
+        # Then
+        self.check_call_state.assert_any_call(
+            ['terraform', 'init', ANY, ANY, ANY, ANY],
+            cwd='infra'
+        )
+
+        self.check_call.assert_any_call(['terraform', 'get', 'infra'])
+
+        self.check_call.assert_any_call(
+            [
+                'terraform', 'plan',
+                '-var', 'component=dummy-component',
+                '-var', 'env=aslive',
+                '-var', 'aws_region=eu-west-12',
+                '-var', 'team=dummy-team',
+                '-var-file', 'infra/platform-config/mmg/dev/eu-west-12.json',
+                '-var-file', ANY,
+                '-var', 'raindrops=roses',
+                '-var', 'whiskers=kittens',
+                'infra'
+            ],
+            env={
+                'JOB_NAME': 'dummy-job-name',
+                'AWS_ACCESS_KEY_ID': self.aws_access_key_id,
+                'AWS_SECRET_ACCESS_KEY': self.aws_secret_access_key,
+                'AWS_SESSION_TOKEN': self.aws_session_token
+            }
+        )
+        terraform_calls = self.check_call.call_args_list
+        assert (
+            (
+                [
+                    'terraform', 'apply',
+                    '-var', 'component=dummy-component',
+                    '-var', 'env=aslive',
+                    '-var', 'aws_region=eu-west-12',
+                    '-var', 'team=dummy-team',
+                    '-var-file',
+                    'infra/platform-config/mmg/dev/eu-west-12.json',
+                    '-var-file', ANY,
+                    '-var', 'raindrops=roses',
+                    '-var', 'whiskers=kittens',
+                    'infra'
+                ],
+            ), ANY
+        ) not in terraform_calls
+
 
 class TestDestroyCLI(unittest.TestCase):
 

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -326,22 +326,22 @@ class TestDeployCLI(unittest.TestCase):
         ) not in terraform_calls
 
 
+@patch('cdflow_commands.cli.rmtree')
+@patch('cdflow_commands.plugins.infrastructure.S3BucketFactory')
+@patch('cdflow_commands.plugins.infrastructure.LockTableFactory')
+@patch('cdflow_commands.plugins.base.os')
+@patch('cdflow_commands.plugins.infrastructure.os')
+@patch('cdflow_commands.cli.Session')
+@patch('cdflow_commands.config.Session')
+@patch('cdflow_commands.config.open', new_callable=mock_open, create=True)
+@patch('cdflow_commands.plugins.base.check_call')
+@patch('cdflow_commands.config.check_output')
+@patch('cdflow_commands.state.check_call')
+@patch('cdflow_commands.state.NamedTemporaryFile')
+@patch('cdflow_commands.state.move')
+@patch('cdflow_commands.state.atexit')
 class TestDestroyCLI(unittest.TestCase):
 
-    @patch('cdflow_commands.cli.rmtree')
-    @patch('cdflow_commands.plugins.infrastructure.S3BucketFactory')
-    @patch('cdflow_commands.plugins.infrastructure.LockTableFactory')
-    @patch('cdflow_commands.plugins.base.os')
-    @patch('cdflow_commands.plugins.infrastructure.os')
-    @patch('cdflow_commands.cli.Session')
-    @patch('cdflow_commands.config.Session')
-    @patch('cdflow_commands.config.open', new_callable=mock_open, create=True)
-    @patch('cdflow_commands.plugins.base.check_call')
-    @patch('cdflow_commands.config.check_output')
-    @patch('cdflow_commands.state.check_call')
-    @patch('cdflow_commands.state.NamedTemporaryFile')
-    @patch('cdflow_commands.state.move')
-    @patch('cdflow_commands.state.atexit')
     def test_destroy_is_configured_and_run(
         self, _1, _2, _3, check_call_state, check_output, check_call,
         mock_open, Session_from_config, Session_from_cli, mock_os_cli,
@@ -451,3 +451,109 @@ class TestDestroyCLI(unittest.TestCase):
         )
 
         rmtree.assert_called_once_with('.terraform/')
+
+    def test_destroy_is_only_planned(
+        self, _1, _2, _3, check_call_state, check_output, check_call,
+        mock_open, Session_from_config, Session_from_cli, mock_os_cli,
+        mock_os_deploy, _4, _5, rmtree
+    ):
+        # Given
+        mock_os_cli.environ = {
+            'JOB_NAME': 'dummy-job-name'
+        }
+        mock_os_deploy.environ = {}
+
+        mock_metadata_file = MagicMock(spec=TextIOWrapper)
+        metadata = {
+            'TEAM': 'dummy-team',
+            'TYPE': 'infrastructure',
+            'REGION': 'eu-west-12',
+            'ACCOUNT_PREFIX': 'mmg'
+        }
+        mock_metadata_file.read.return_value = json.dumps(metadata)
+
+        mock_dev_file = MagicMock(spec=TextIOWrapper)
+        dev_config = {
+            'platform_config': {
+                'account_id': 123456789,
+            }
+        }
+        mock_dev_file.read.return_value = json.dumps(dev_config)
+
+        mock_prod_file = MagicMock(spec=TextIOWrapper)
+        prod_config = {
+            'platform_config': {
+                'account_id': 987654321,
+            }
+        }
+        mock_prod_file.read.return_value = json.dumps(prod_config)
+
+        mock_open.return_value.__enter__.side_effect = (
+            f for f in (mock_metadata_file, mock_dev_file, mock_prod_file)
+        )
+
+        mock_sts_client = Mock()
+        mock_sts_client.assume_role.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'dummy-access-key',
+                'SecretAccessKey': 'dummy-secret-key',
+                'SessionToken': 'dummy-session-token',
+            }
+        }
+
+        mock_root_session = Mock()
+        mock_root_session.client.return_value = mock_sts_client
+        mock_root_session.region_name = 'eu-west-12'
+        Session_from_cli.return_value = mock_root_session
+
+        aws_access_key_id = 'dummy-access-key-id'
+        aws_secret_access_key = 'dummy-secret-access-key'
+        aws_session_token = 'dummy-session-token'
+        mock_assumed_session = Mock()
+        mock_assumed_session.region_name = 'eu-west-12'
+        mock_assumed_session.get_credentials.return_value = BotoCreds(
+            aws_access_key_id,
+            aws_secret_access_key,
+            aws_session_token
+        )
+
+        Session_from_config.return_value = mock_assumed_session
+
+        component_name = 'dummy-component'
+
+        check_output.return_value = 'git@github.com:org/{}.git'.format(
+            component_name
+        ).encode('utf-8')
+
+        # When
+        cli.run(['destroy', 'aslive', '--plan-only'])
+
+        # Then
+        check_call_state.assert_any_call(
+            ['terraform', 'init', ANY, ANY, ANY, ANY],
+            cwd='/cdflow/tf-destroy'
+        )
+
+        check_call.assert_any_call(
+            [
+                'terraform', 'plan', '-destroy',
+                '-var', 'aws_region=eu-west-12',
+                '/cdflow/tf-destroy'
+            ],
+            env={
+                'AWS_ACCESS_KEY_ID': aws_access_key_id,
+                'AWS_SECRET_ACCESS_KEY': aws_secret_access_key,
+                'AWS_SESSION_TOKEN': aws_session_token
+            }
+        )
+
+        terraform_calls = check_call.call_args_list
+        assert (
+            (
+                [
+                    'terraform', 'destroy', '-force',
+                    '-var', 'aws_region=eu-west-12',
+                    '/cdflow/tf-destroy'
+                ],
+            ), ANY
+        ) not in terraform_calls

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -275,7 +275,7 @@ class TestDeployCLI(unittest.TestCase):
             'deploy', 'aslive',
             '--var', 'raindrops=roses',
             '--var', 'whiskers=kittens',
-            '--plan'
+            '--plan-only'
         ])
 
         # Then

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -108,80 +108,48 @@ class TestReleaseCLI(unittest.TestCase):
 BotoCreds = namedtuple('BotoCreds', ['access_key', 'secret_key', 'token'])
 
 
+@patch('cdflow_commands.cli.rmtree')
+@patch('cdflow_commands.plugins.aws_lambda.check_call')
+@patch('cdflow_commands.plugins.aws_lambda.get_secrets')
+@patch('cdflow_commands.config.Session')
+@patch('cdflow_commands.cli.Session')
+@patch('cdflow_commands.plugins.aws_lambda.os')
+@patch('cdflow_commands.plugins.aws_lambda.S3BucketFactory')
+@patch('cdflow_commands.config.open', new_callable=mock_open, create=True)
+@patch('cdflow_commands.state.check_call')
+@patch('cdflow_commands.plugins.aws_lambda.LockTableFactory')
+@patch('cdflow_commands.state.NamedTemporaryFile')
+@patch('cdflow_commands.state.move')
+@patch('cdflow_commands.state.atexit')
 class TestDeployCLI(unittest.TestCase):
 
-    @patch('cdflow_commands.cli.rmtree')
-    @patch('cdflow_commands.plugins.aws_lambda.check_call')
-    @patch('cdflow_commands.plugins.aws_lambda.get_secrets')
-    @patch('cdflow_commands.config.Session')
-    @patch('cdflow_commands.cli.Session')
-    @patch('cdflow_commands.plugins.aws_lambda.os')
-    @patch('cdflow_commands.plugins.aws_lambda.S3BucketFactory')
-    @patch('cdflow_commands.config.open', new_callable=mock_open, create=True)
-    @patch('cdflow_commands.state.check_call')
-    @patch('cdflow_commands.plugins.aws_lambda.LockTableFactory')
-    @patch('cdflow_commands.state.NamedTemporaryFile')
-    @patch('cdflow_commands.state.move')
-    @patch('cdflow_commands.state.atexit')
-    def test_deploy_is_configured_and_run(
-        self, _1, _2, _3, _4, check_call_state, mock_open,
-        mock_lambda_s3_factory, mock_lambda_os, session_from_cli,
-        session_from_config, get_secrets, check_call, rmtree
-    ):
-        # Given
-        mock_metadata_file = MagicMock(spec=TextIOWrapper)
+    def setUp(self):
+        DUMMY_REGION = 'eu-west-12'
         metadata = {
             'TEAM': 'dummy-team',
             'TYPE': 'lambda',
-            'REGION': 'eu-west-12',
+            'REGION': DUMMY_REGION,
             'ACCOUNT_PREFIX': 'mmg',
             'HANDLER': 'dummy-handler',
             'RUNTIME': 'dummy-runtime'
         }
-        mock_metadata_file.read.return_value = json.dumps(metadata)
-        mock_dev_file = MagicMock(spec=TextIOWrapper)
+        self._mock_metadata_file = MagicMock(spec=TextIOWrapper)
+        self._mock_metadata_file.read.return_value = json.dumps(metadata)
         dev_config = {
             'platform_config': {
                 'account_id': 123456789,
             }
         }
-        mock_dev_file.read.return_value = json.dumps(dev_config)
-
-        mock_prod_file = MagicMock(spec=TextIOWrapper)
+        self._mock_dev_file = MagicMock(spec=TextIOWrapper)
+        self._mock_dev_file.read.return_value = json.dumps(dev_config)
         prod_config = {
             'platform_config': {
                 'account_id': 987654321,
             }
         }
-        mock_prod_file.read.return_value = json.dumps(prod_config)
-
-        mock_open.return_value.__enter__.side_effect = (
-            f for f in (mock_metadata_file, mock_dev_file, mock_prod_file)
-        )
-
-        mock_root_session = Mock()
-        mock_root_session.region_name = 'eu-west-12'
-        session_from_cli.return_value = mock_root_session
-
-        mock_s3_client = Mock()
-        mock_s3_client.list_buckets.return_value = {
-            'Buckets': [],
-            'Owner': {
-                'DisplayName': 'string',
-                'ID': 'string'
-            }
-        }
-
-        mock_assumed_session = Mock()
-        mock_assumed_session.region_name = 'eu-west-12'
-        mock_assumed_session.get_credentials.return_value = BotoCreds(
-            'dummy-access-key-id',
-            'dummy-secret-access-key',
-            'dummy-session-token'
-        )
-
-        session_from_config.return_value = mock_assumed_session
-
+        self._mock_prod_file = MagicMock(spec=TextIOWrapper)
+        self._mock_prod_file.read.return_value = json.dumps(prod_config)
+        self._mock_root_session = Mock()
         mock_sts = Mock()
         mock_sts.assume_role.return_value = {
             'Credentials': {
@@ -196,12 +164,44 @@ class TestDeployCLI(unittest.TestCase):
             },
             'PackedPolicySize': 123
         }
-        mock_root_session.client.return_value = mock_sts
+        self._mock_root_session.region_name = DUMMY_REGION
+        self._mock_root_session.client.return_value = mock_sts
+        self._mock_s3_client = Mock()
+        self._mock_s3_client.list_buckets.return_value = {
+            'Buckets': [],
+            'Owner': {
+                'DisplayName': 'string',
+                'ID': 'string'
+            }
+        }
+
+        self._mock_assumed_session = Mock()
+        self._mock_assumed_session.region_name = DUMMY_REGION
+        self._mock_assumed_session.get_credentials.return_value = BotoCreds(
+            'dummy-access-key-id',
+            'dummy-secret-access-key',
+            'dummy-session-token'
+        )
+
+    def test_deploy_is_configured_and_run(
+        self, _1, _2, _3, _4, check_call_state, mock_open,
+        mock_lambda_s3_factory, mock_lambda_os, session_from_cli,
+        session_from_config, get_secrets, check_call, rmtree
+    ):
+        # Given
+        mock_open.return_value.__enter__.side_effect = (
+            f for f in (
+                self._mock_metadata_file,
+                self._mock_dev_file,
+                self._mock_prod_file
+            )
+        )
+        session_from_cli.return_value = self._mock_root_session
+        session_from_config.return_value = self._mock_assumed_session
         mock_lambda_os.environ = {
             'JOB_NAME': 'dummy-job-name'
         }
         get_secrets.return_value = {}
-
         component_name = 'dummy-component'
 
         # When
@@ -258,3 +258,77 @@ class TestDeployCLI(unittest.TestCase):
                 'AWS_SESSION_TOKEN': 'dummy-session-token'
             }
         )
+
+    def test_deploy_is_planned_with_flag(
+        self, _1, _2, _3, _4, check_call_state, mock_open,
+        mock_lambda_s3_factory, mock_lambda_os, session_from_cli,
+        session_from_config, get_secrets, check_call, rmtree
+    ):
+        # Given
+        mock_open.return_value.__enter__.side_effect = (
+            f for f in (
+                self._mock_metadata_file,
+                self._mock_dev_file,
+                self._mock_prod_file
+            )
+        )
+
+        session_from_cli.return_value = self._mock_root_session
+        session_from_config.return_value = self._mock_assumed_session
+        mock_lambda_os.environ = {
+            'JOB_NAME': 'dummy-job-name'
+        }
+        get_secrets.return_value = {}
+        component_name = 'dummy-component'
+
+        # When
+        cli.run(['deploy', 'aslive', '1.2.3', '-c', component_name, '--plan'])
+
+        # Then
+        check_call_state.assert_any_call(
+            ['terraform', 'init', ANY, ANY, ANY, ANY],
+            cwd='infra'
+        )
+
+        check_call.assert_any_call(['terraform', 'get', 'infra'])
+
+        check_call.assert_any_call(
+            [
+                'terraform', 'plan',
+                '-var', 'component=dummy-component',
+                '-var', 'env=aslive',
+                '-var', 'aws_region=eu-west-12',
+                '-var', 'team=dummy-team',
+                '-var', 'version=1.2.3',
+                '-var', 'handler=dummy-handler',
+                '-var', 'runtime=dummy-runtime',
+                '-var-file', 'infra/platform-config/mmg/dev/eu-west-12.json',
+                '-var-file', ANY,
+                'infra'
+            ],
+            env={
+                'JOB_NAME': 'dummy-job-name',
+                'AWS_ACCESS_KEY_ID': 'dummy-access-key-id',
+                'AWS_SECRET_ACCESS_KEY': 'dummy-secret-access-key',
+                'AWS_SESSION_TOKEN': 'dummy-session-token'
+            }
+        )
+        terraform_calls = check_call.call_args_list
+        assert (
+            (
+                [
+                    'terraform', 'apply',
+                    '-var', 'component=dummy-component',
+                    '-var', 'env=aslive',
+                    '-var', 'aws_region=eu-west-12',
+                    '-var', 'team=dummy-team',
+                    '-var', 'version=1.2.3',
+                    '-var', 'handler=dummy-handler',
+                    '-var', 'runtime=dummy-runtime',
+                    '-var-file',
+                    'infra/platform-config/mmg/dev/eu-west-12.json',
+                    '-var-file', ANY,
+                    'infra'
+                ],
+            ), ANY
+        ) not in terraform_calls, 'apply is in terraform calls'


### PR DESCRIPTION
When we change infrastructure we might want to plan first without
calling apply immediately. This flag will stop apply from being run.

Early feedback would be appreciated as this is an interface change. Also good to get feedback on the use of `call_args_list` as it tests what I want but there could be a prettier way?

```
       terraform_calls = check_call.call_args_list
+        assert len(terraform_calls) < TERRAFORM_FULL_LIFECYCLE_CALL_COUNT
+        assert (
+            (
+                ['terraform', 'plan'] + ignored_parameters + ['infra'],
+            ), ANY
+        ) in terraform_calls
+        assert (
+            (
+                ['terraform', 'apply'] + ignored_parameters + ['infra'],
+            ), ANY
+        ) not in terraform_calls
+
```

JIRA: PLAN-958