### PR TITLE
Throw friendly exception for unsupported project

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -18,14 +18,15 @@ import sys
 from shutil import rmtree
 
 from boto3.session import Session
+
 from cdflow_commands.config import (
     get_component_name, load_global_config, load_service_metadata
 )
-from cdflow_commands.exceptions import UserFacingError
+from cdflow_commands.exceptions import UnknownProjectTypeError, UserFacingError
 from cdflow_commands.logger import logger
+from cdflow_commands.plugins.aws_lambda import build_lambda_plugin
 from cdflow_commands.plugins.ecs import build_ecs_plugin
 from cdflow_commands.plugins.infrastructure import build_infrastructure_plugin
-from cdflow_commands.plugins.aws_lambda import build_lambda_plugin
 from docopt import docopt
 
 
@@ -103,6 +104,10 @@ def build_plugin(project_type, **kwargs):
             kwargs['global_config'],
             kwargs['root_session'],
             kwargs['plan_only']
+        )
+    else:
+        raise UnknownProjectTypeError(
+            'Unsupported project type specified in service.json'
         )
     return plugin
 

--- a/cdflow_commands/exceptions.py
+++ b/cdflow_commands/exceptions.py
@@ -19,3 +19,7 @@ class FixedMessageError(CDFlowError):
 
 class UserFacingFixedMessageError(UserFacingError, FixedMessageError):
     pass
+
+
+class UnknownProjectTypeError(UserFacingError):
+    pass

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,7 +1,7 @@
 import unittest
 
 from cdflow_commands import cli
-from cdflow_commands.exceptions import UserFacingError
+from cdflow_commands.exceptions import UnknownProjectTypeError, UserFacingError
 from mock import patch
 
 
@@ -81,3 +81,19 @@ class TestUserFacingErrorThrown(unittest.TestCase):
 
         message_template = 'DEBUG:cdflow_commands.logger:No path {} to remove'
         assert message_template.format('.terraform/') in logs.output
+
+
+class TestCliBuildPlugin(unittest.TestCase):
+    def test_unsupported_project_type(self):
+        # Given
+        project_type = 'unknown'
+
+        # When / Then
+        with self.assertRaises(UnknownProjectTypeError) as context:
+            cli.build_plugin(project_type)
+
+        self.assertTrue(
+            'Unsupported project type specified in service.json' in str(
+                context.exception
+            )
+        )


### PR DESCRIPTION
We want to throw friendly exception when unsupported project type is specified in `service.json`

JIRA: PLAT-969