### PR TITLE
Switch Terraform to use individual providers && update Terraform to 0.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,33 @@
 FROM python:3-alpine
 
-ENV TERRAFORM_VERSION=0.9.11
-ENV ACME_VERSION=0.3.0
+ENV TERRAFORM_VERSION=0.10.0
+
+ENV TERRAFORM_PROVIDER_AWS_VERSION=0.1.2
+ENV TERRAFORM_PROVIDER_FASTLY_VERSION=0.1.2_le-support
+ENV TERRAFORM_PROVIDER_NULL_VERSION=0.1.0
+ENV TERRAFORM_PROVIDER_TEMPLATE_VERSION=0.1.1
+ENV TERRAFORM_PROVIDER_ACME_VERSION=0.3.0
+ENV TERRAFORM_PROVIDER_LOGENTRIES_VERSION=0.1.0
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/apk/repositories
 RUN apk update
-RUN apk add gcc musl-dev libffi-dev openssl-dev docker curl git
+RUN apk add gcc musl-dev libffi-dev openssl-dev docker curl git zip unzip wget
 
 RUN cd /tmp && \
     curl -sSLO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    unzip terraform_*_linux_amd64.zip -d /usr/bin && \
-    curl -sSLO https://github.com/paybyphone/terraform-provider-acme/releases/download/v${ACME_VERSION}/terraform-provider-acme_v${ACME_VERSION}_linux_amd64.zip && \
-    unzip terraform-provider-acme_*_linux_amd64.zip -d /usr/bin && \
+        unzip terraform_*_linux_amd64.zip -d /usr/bin && \
+    wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-aws_v${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-aws_*_linux_amd64.zip -d /usr/bin && \
+    wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-fastly_v${TERRAFORM_PROVIDER_FASTLY_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-fastly_*_linux_amd64.zip -d /usr/bin && \
+    wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-null_v${TERRAFORM_PROVIDER_NULL_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-null_*_linux_amd64.zip -d /usr/bin && \
+    wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-template_v${TERRAFORM_PROVIDER_TEMPLATE_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-template_*_linux_amd64.zip -d /usr/bin && \
+    wget -q https://releases.hashicorp.com/terraform-provider-logentries/${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}/terraform-provider-logentries_${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-logentries_*_linux_amd64.zip -d /usr/bin && \
+    wget -q https://github.com/paybyphone/terraform-provider-acme/releases/download/v${TERRAFORM_PROVIDER_ACME_VERSION}/terraform-provider-acme_v${TERRAFORM_PROVIDER_ACME_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-acme_*_linux_amd64.zip -d /usr/bin && \
     rm -rf /tmp/* && \
     rm -rf /var/tmp/*
 

--- a/cdflow_commands/state.py
+++ b/cdflow_commands/state.py
@@ -75,6 +75,7 @@ def initialise_terraform_backend(
     check_call(
         [
             'terraform', 'init',
+            f'-get-plugins=false',
             f'-backend-config=bucket={bucket_name}',
             f'-backend-config=region={aws_region}',
             f'-backend-config=key={key}',
@@ -83,15 +84,20 @@ def initialise_terraform_backend(
         cwd=directory
     )
 
-    from_path = abspath(f'{directory}/.terraform/terraform.tfstate')
+    from_path_statefile = abspath(f'{directory}/.terraform/terraform.tfstate')
+    from_path_plugins = abspath(f'{directory}/.terraform/plugins')
     to_path = abspath(f'{directory}/../.terraform/')
 
-    logger.debug(f'Moving {from_path} to {to_path}')
     try:
         mkdir(to_path)
     except OSError:
         logger.debug(f'{to_path} already exists - not creating')
-    move(from_path, to_path)
+
+    logger.debug(f'Moving {from_path_statefile} to {to_path}')
+    move(from_path_statefile, to_path)
+
+    logger.debug(f'Moving {from_path_plugins} to {to_path}')
+    move(from_path_plugins, to_path)
 
 
 def state_file_key(environment_name, component_name):


### PR DESCRIPTION
Starting with Terraform 0.10, Terraform Providers will be split into separate repositories hence being a separate to Terraform core itself entities.

Default Terraform behaviour will be downloading latest versions of providers available; given this default behaviour, few more points to considerate:

1). We can "pin" specific versions of Terraform Providers using .terraformrc file
2). These will be hosted on Github making Github a potential dependency for making new cdflow-commands releases
3). At the moment there's not way to use unreleased Terraform Providers - use-case here being when we've got a buggy provider, or provider which is missing feature - we do the work to bring it up to our requirements but are unable to use it until a new version of provider is available.

Given this, I've decided it's best to have a S3 bucket which will host compiled Terraform Providers binaries and these will be fetched during container-baking process.

Also, modify cdflow-commands to make sure we use specific directory to keep providers and we don't try to fetch them off the internet (even if missing!).

NOTE: the binaries need to be compiled for Alpine, otherwise it's failing due to incorrect linking.

**JIRA**: PLAT-1030