### PR TITLE
Stop terraform asking for input

### DIFF
--- a/cdflow_commands/deploy.py
+++ b/cdflow_commands/deploy.py
@@ -62,7 +62,7 @@ class Deploy:
         )
 
     def _build_parameters(self, command, secrets_file_path=None):
-        parameters = [TERRAFORM_BINARY, command]
+        parameters = [TERRAFORM_BINARY, command, '-input=false']
         if command == 'plan':
             parameters = self._add_plan_parameters(
                 parameters, secrets_file_path

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -90,7 +90,7 @@ class TestDeploy(unittest.TestCase):
 
             check_call.assert_any_call(
                 [
-                    'terraform', 'plan',
+                    'terraform', 'plan', '-input=false',
                     '-var', 'env={}'.format(environment),
                     '-var', 'aws_region={}'.format(aws_region),
                     '-var-file', 'release.json',
@@ -167,7 +167,10 @@ class TestDeploy(unittest.TestCase):
             deploy.run()
 
             check_call.assert_any_call(
-                ['terraform', 'apply', 'plan-{}'.format(utcnow)],
+                [
+                    'terraform', 'apply', '-input=false',
+                    'plan-{}'.format(utcnow)
+                ],
                 cwd=release_path,
                 env={
                     'AWS_ACCESS_KEY_ID': credentials.access_key,
@@ -245,7 +248,7 @@ class TestDeploy(unittest.TestCase):
 
             check_call.assert_called_once_with(
                 [
-                    'terraform', 'plan',
+                    'terraform', 'plan', '-input=false',
                     '-var', 'env={}'.format(environment),
                     '-var', 'aws_region={}'.format(aws_region),
                     '-var-file', 'release.json',
@@ -330,7 +333,7 @@ class TestDeploy(unittest.TestCase):
 
             check_call.assert_any_call(
                 [
-                    'terraform', 'plan',
+                    'terraform', 'plan', '-input=false',
                     '-var', 'env={}'.format(environment),
                     '-var', 'aws_region={}'.format(aws_region),
                     '-var-file', 'release.json',
@@ -419,7 +422,7 @@ class TestDeploy(unittest.TestCase):
 
             check_call.assert_any_call(
                 [
-                    'terraform', 'plan',
+                    'terraform', 'plan', '-input=false',
                     '-var', 'env={}'.format(environment),
                     '-var', 'aws_region={}'.format(aws_region),
                     '-var-file', 'release.json',

--- a/test/test_integration_cli.py
+++ b/test/test_integration_cli.py
@@ -170,7 +170,7 @@ class TestDeployCLI(unittest.TestCase):
 
         check_call_deploy.assert_any_call(
             [
-                'terraform', 'plan',
+                'terraform', 'plan', '-input=false',
                 '-var', 'env=live',
                 '-var', 'aws_region={}'.format(
                     mock_assumed_session.region_name
@@ -194,7 +194,8 @@ class TestDeployCLI(unittest.TestCase):
 
         check_call_deploy.assert_any_call(
             [
-                'terraform', 'apply', 'plan-{}'.format(time.return_value),
+                'terraform', 'apply', '-input=false',
+                'plan-{}'.format(time.return_value),
             ],
             env={
                 'foo': 'bar',
@@ -226,7 +227,7 @@ class TestDeployCLI(unittest.TestCase):
         # Then
         check_call_deploy.assert_called_once_with(
             [
-                'terraform', 'plan',
+                'terraform', 'plan', '-input=false',
                 '-var', 'env=live',
                 '-var', 'aws_region={}'.format(
                     mock_assumed_session.region_name


### PR DESCRIPTION
Using the wrapper if terraform asks for input then you see the prompt
being generated continuously without the opportunity to input.

JIRA: PLAT-1072