### PR TITLE
Checking for 'config' folder before adding

### DIFF
--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -79,7 +79,8 @@ class Release:
                 '{}/{}'.format(getcwd(), INFRASTRUCTURE_DEFINITIONS_PATH)
             )
 
-            self._copy_app_config_files(base_dir)
+            if os.path.exists(CONFIG_BASE_PATH):
+                self._copy_app_config_files(base_dir)
             self._copy_platform_config_files(base_dir)
             self._copy_infra_files(base_dir)
 


### PR DESCRIPTION
Before we create the release, we want to check to see if the app config
directory exists. If it doesn't we should just continue as not all
cdflow releases will need/usse this directory.

JIRA: PLAT-1075