### PR TITLE
Use absolute path for on-docker-build

### DIFF
--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -37,7 +37,9 @@ class ReleasePlugin:
     def _on_docker_build(self):
         if path.exists(self.ON_BUILD_HOOK):
             try:
-                check_call([self.ON_BUILD_HOOK, self._image_name])
+                check_call([
+                    path.abspath(self.ON_BUILD_HOOK), self._image_name
+                ])
             except CalledProcessError as e:
                 raise OnDockerBuildError(str(e))
 


### PR DESCRIPTION
check_call needs an absolute path, so this was failing.