### PR TITLE
Added tag latest to release built with cdflow & use --cache-from command when building

### DIFF
--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -133,6 +133,6 @@ class ReleasePlugin:
         check_call(['docker', 'push', image_name])
 
     def _docker_tag_latest(self):
-        check_call(
-            ['docker', 'tag', self._image_name, self._latest_image_name]
-        )
+        check_call([
+            'docker', 'tag', self._image_name, self._latest_image_name
+        ])

--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -22,7 +22,11 @@ class ReleasePlugin:
         self._account_scheme = account_scheme
 
     def create(self):
-        check_call(['docker', 'build', '-t', self._image_name, '.'])
+        check_call([
+            'docker', 'build',
+            '--cache-from', self._latest_image_name,
+            '-t', self._image_name, '.'
+        ])
 
         self._on_docker_build()
 

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -183,6 +183,64 @@ class TestRelease(unittest.TestCase):
                 'docker', 'push', image_name
             ])
 
+    @given(fixed_dictionaries({
+        'proxy_endpoint': text(
+            alphabet=IDENTIFIER_ALPHABET + ':/', min_size=8, max_size=16
+        ),
+        'username': text(
+            alphabet=IDENTIFIER_ALPHABET, min_size=8, max_size=16
+        ),
+        'password': text(
+            alphabet=IDENTIFIER_ALPHABET, min_size=8, max_size=16
+        )
+    }))
+    def test_build_with_version_pushes_to_ecr_repo_with_latest_tag(
+        self, fixtures
+    ):
+        # Given
+        proxy_endpoint = fixtures['proxy_endpoint']
+        username = fixtures['username']
+        password = fixtures['password']
+
+        self._ecr_client.describe_repositories = Mock()
+        self._set_mock_get_authorization_token(
+            username, password, proxy_endpoint
+        )
+
+        with patch('cdflow_commands.plugins.ecs.check_call') as check_call:
+            # When
+            self._plugin.create()
+
+            # Then
+            self._ecr_client.describe_repositories.assert_called_once_with(
+                repositoryNames=[self._component_name]
+            )
+
+            self._ecr_client.get_authorization_token.assert_called_once()
+
+            check_call.assert_any_call([
+                'docker', 'login',
+                '-u', username, '-p', password, proxy_endpoint
+            ])
+
+            image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
+                self._account_id, self._region, self._component_name,
+                self._version
+            )
+
+            latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
+                self._account_id, self._region, self._component_name,
+                'latest'
+            )
+
+            check_call.assert_any_call([
+                'docker', 'tag', image_name, latest_image_name
+            ])
+
+            check_call.assert_any_call([
+                'docker', 'push', latest_image_name
+            ])
+
     @given(text(alphabet=IDENTIFIER_ALPHABET, min_size=8, max_size=16))
     def test_ecr_repo_created_when_it_does_not_exist(self, component_name):
         # Given

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -104,6 +104,10 @@ class TestRelease(unittest.TestCase):
             account_id, region, component_name, 'dev'
         )
 
+        latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
+            account_id, region, component_name, 'latest'
+        )
+
         plugin = ReleasePlugin(release, account_scheme)
 
         with patch('cdflow_commands.plugins.ecs.check_call') as check_call:
@@ -114,7 +118,12 @@ class TestRelease(unittest.TestCase):
             assert plugin_data == {'image_id': image_name}
 
             check_call.assert_called_once_with(
-                ['docker', 'build', '-t', image_name, '.']
+                [
+                    'docker',
+                    'build',
+                    '--cache-from', latest_image_name,
+                    '-t', image_name, '.'
+                ]
             )
 
     @given(text(alphabet=IDENTIFIER_ALPHABET, min_size=1, max_size=12))
@@ -132,8 +141,17 @@ class TestRelease(unittest.TestCase):
                 self._account_id, self._region, self._component_name, version
             )
 
+            latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
+                self._account_id, self._region, self._component_name, 'latest'
+            )
+
             check_call.assert_any_call(
-                ['docker', 'build', '-t', image_name, '.']
+                [
+                    'docker',
+                    'build',
+                    '--cache-from', latest_image_name,
+                    '-t', image_name, '.'
+                ]
             )
 
     @given(fixed_dictionaries({

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -117,14 +117,12 @@ class TestRelease(unittest.TestCase):
             # Then
             assert plugin_data == {'image_id': image_name}
 
-            check_call.assert_called_once_with(
-                [
-                    'docker',
-                    'build',
-                    '--cache-from', latest_image_name,
-                    '-t', image_name, '.'
-                ]
-            )
+            check_call.assert_called_once_with([
+                'docker',
+                'build',
+                '--cache-from', latest_image_name,
+                '-t', image_name, '.'
+            ])
 
     @given(text(alphabet=IDENTIFIER_ALPHABET, min_size=1, max_size=12))
     def test_tags_container_with_version(self, version):
@@ -145,14 +143,12 @@ class TestRelease(unittest.TestCase):
                 self._account_id, self._region, self._component_name, 'latest'
             )
 
-            check_call.assert_any_call(
-                [
-                    'docker',
-                    'build',
-                    '--cache-from', latest_image_name,
-                    '-t', image_name, '.'
-                ]
-            )
+            check_call.assert_any_call([
+                'docker',
+                'build',
+                '--cache-from', latest_image_name,
+                '-t', image_name, '.'
+            ])
 
     @given(fixed_dictionaries({
         'proxy_endpoint': text(

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -117,6 +117,12 @@ class TestReleaseCLI(unittest.TestCase):
             component_name,
             version
         )
+        latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
+            123456789,
+            'us-north-4',
+            component_name,
+            'latest'
+        )
 
         cli.run([
             'release', '--platform-config', 'path/to/config',
@@ -130,7 +136,11 @@ class TestReleaseCLI(unittest.TestCase):
             RoleSessionName=mock_os.environ['JOB_NAME'],
         )
 
-        check_call.assert_any_call(['docker', 'build', '-t', image_name, '.'])
+        check_call.assert_any_call([
+            'docker', 'build',
+            '--cache-from', latest_image_name,
+            '-t', image_name, '.'
+        ])
         check_call.assert_any_call(['docker', 'push', image_name])
 
         mock_session.resource.return_value.Object.assert_called_once_with(
@@ -246,8 +256,18 @@ class TestReleaseCLI(unittest.TestCase):
             component_name,
             version
         )
+        latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
+            123456789,
+            'us-north-4',
+            component_name,
+            'latest'
+        )
 
-        check_call.assert_any_call(['docker', 'build', '-t', image_name, '.'])
+        check_call.assert_any_call([
+            'docker', 'build',
+            '--cache-from', latest_image_name,
+            '-t', image_name, '.'
+        ])
         check_call.assert_any_call(['docker', 'push', image_name])
 
         mock_session.resource.return_value.Object.assert_called_once_with(


### PR DESCRIPTION
When a release is build and pushed to ecr we also want to tag it with
the "latest" tag. We use this tag for the docker `--build-cache` command which has been added to all the docker builds.

JIRA: PLAT-998