### PR TITLE
Stop showing python stacktrace when terraform operations fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .hypothesis/*
 !.hypothesis/examples/*
+__pycache__

--- a/cdflow_commands/deploy.py
+++ b/cdflow_commands/deploy.py
@@ -1,7 +1,6 @@
 import json
 import os
 from os import path
-from subprocess import check_call
 from tempfile import NamedTemporaryFile
 from time import time
 
@@ -11,6 +10,7 @@ from cdflow_commands.constants import (
     PLATFORM_CONFIG_BASE_PATH, RELEASE_METADATA_FILE, TERRAFORM_BINARY
 )
 from cdflow_commands.logger import logger
+from cdflow_commands.process import check_call
 
 
 class Deploy:

--- a/cdflow_commands/destroy.py
+++ b/cdflow_commands/destroy.py
@@ -1,11 +1,11 @@
 import os
-from subprocess import check_call
 from time import time
 
 from cdflow_commands.config import env_with_aws_credetials
 from cdflow_commands.constants import (
     TERRAFORM_BINARY, TERRAFORM_DESTROY_DEFINITION
 )
+from cdflow_commands.process import check_call
 
 
 class Destroy:

--- a/cdflow_commands/process.py
+++ b/cdflow_commands/process.py
@@ -1,0 +1,11 @@
+from cdflow_commands.exceptions import UserFacingError
+from cdflow_commands.logger import logger
+
+from subprocess import CalledProcessError, check_call as _check_call
+
+
+def check_call(*args, **kwargs):
+    try:
+        _check_call(*args, **kwargs)
+    except CalledProcessError as e:
+        raise UserFacingError(e)

--- a/cdflow_commands/process.py
+++ b/cdflow_commands/process.py
@@ -1,5 +1,4 @@
 from cdflow_commands.exceptions import UserFacingError
-from cdflow_commands.logger import logger
 
 from subprocess import CalledProcessError, check_call as _check_call
 

--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -5,7 +5,6 @@ import os
 from os import chmod, getcwd, path, mkdir
 from shutil import copytree, make_archive
 import shutil
-from subprocess import check_call
 from tempfile import TemporaryDirectory
 from time import time
 from zipfile import ZipFile
@@ -15,6 +14,7 @@ from cdflow_commands.constants import (
     PLATFORM_CONFIG_BASE_PATH, RELEASE_METADATA_FILE, TERRAFORM_BINARY
 )
 from cdflow_commands.logger import logger
+from cdflow_commands.process import check_call
 from cdflow_commands.zip_patch import _make_zipfile
 
 # Monkey patch the standard library...

--- a/cdflow_commands/state.py
+++ b/cdflow_commands/state.py
@@ -4,7 +4,6 @@ from hashlib import sha1
 from os import mkdir, unlink
 from os.path import abspath
 from shutil import move
-from subprocess import check_call
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 
@@ -13,6 +12,7 @@ from botocore.exceptions import ClientError
 from cdflow_commands.config import env_with_aws_credetials
 from cdflow_commands.exceptions import CDFlowError
 from cdflow_commands.logger import logger
+from cdflow_commands.process import check_call
 
 TFSTATE_NAME_PREFIX = 'cdflow-tfstate'
 LAMBDA_BUCKET_NAME = 'cdflow-lambda-releases'

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -1,0 +1,30 @@
+import unittest
+
+from cdflow_commands.exceptions import UserFacingError
+from cdflow_commands.process import check_call
+from mock import patch
+from subprocess import CalledProcessError
+
+
+class TestProcess(unittest.TestCase):
+
+    @patch('cdflow_commands.process._check_call')
+    def test_check_call(self, _check_call):
+        # Given When
+        check_call('echo', {})
+
+        # Then
+        _check_call.assert_called_once_with('echo', {})
+
+    @patch('cdflow_commands.process._check_call')
+    def test_check_call_throws_user_facing_exception(self, _check_call):
+        # Given
+        _check_call.side_effect = CalledProcessError(1, 'echo')
+
+        # When Then
+        self.assertRaises(
+            UserFacingError,
+            check_call,
+            'echo',
+            {}
+        )


### PR DESCRIPTION
PLAT-1083

Output sample:
```
Downloading modules...
Get: git::https://github.com/mergermarket/tf_ecs_service_infrastructure.git
Get: git::https://github.com/mergermarket/tf_route53_dns.git
Get: git::https://github.com/mergermarket/tf_alb_listener_rules.git
Get: git::https://github.com/mergermarket/tf_ecs_update_monitor.git
Get: git::https://github.com/mergermarket/tf_load_balanced_ecs_service.git
Get: git::https://github.com/mergermarket/tf_ecs_task_definition.git
Get: git::https://github.com/mergermarket/tf_ecs_container_definition.git

Initializing the backend...
"lock_table": [DEPRECATED] please use the dynamodb_table attribute

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
3 error(s) occurred:

* Required variable not set: alb_listener_arn
* Required variable not set: alb_dns_name
* variable platform_config should be type string, got map
[2017-09-06 10:29:17] Command '['terraform', 'plan', '-input=false', '-var', 'env=dev', '-var', 'aws_region=eu-west-1', '-var-file', 'release.json', '-var-file', 'platform-config/mmgdev/eu-west-1.json', '-var-file', '/tmp/tmpzvl7wg_i', '-out', 'plan-1504693753.2940521', '-var-file', 'config/common.json', 'infra']' returned non-zero exit status 1.
```