### PR TITLE
Plat 1081 fix role session name inconsistency

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -23,8 +23,7 @@ from subprocess import check_output
 from boto3.session import Session
 
 from cdflow_commands.config import (
-    assume_role, get_component_name, get_role_session_name,
-    load_manifest, build_account_scheme
+    assume_role, get_component_name, load_manifest, build_account_scheme
 )
 from cdflow_commands.constants import (
     INFRASTRUCTURE_DEFINITIONS_PATH, TERRAFORM_DESTROY_DEFINITION,
@@ -74,10 +73,8 @@ def _run(argv):
         root_session.resource('s3'), manifest.account_scheme_url
     )
 
-    role_session_name = get_role_session_name(os.environ)
-
     release_account_session = assume_role(
-        root_session, account_scheme.release_account.id, role_session_name,
+        root_session, account_scheme.release_account.id,
         account_scheme.default_region,
     )
 
@@ -127,12 +124,10 @@ def run_deploy(
     environment = args['<environment>']
     component_name = get_component_name(args['--component'])
     version = args['<version>']
-    role_session_name = get_role_session_name(os.environ)
     account_id = account_scheme.account_for_environment(environment).id
 
     deploy_account_session = assume_role(
-        root_session, account_id, role_session_name,
-        account_scheme.default_region,
+        root_session, account_id, account_scheme.default_region,
     )
 
     with fetch_release(
@@ -165,13 +160,11 @@ def run_deploy(
 def run_destroy(root_session, account_scheme, manifest, args):
     environment = args['<environment>']
     component_name = get_component_name(args['--component'])
-    role_session_name = get_role_session_name(os.environ)
     account_id = account_scheme.account_for_environment(environment).id
 
     logger.debug('Assuming role in {}'.format(account_id))
     destroy_account_session = assume_role(
-        root_session, account_id, role_session_name,
-        account_scheme.default_region,
+        root_session, account_id, account_scheme.default_region,
     )
 
     initialise_terraform(

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -51,13 +51,14 @@ def load_manifest():
         )
 
 
-def assume_role(root_session, acccount_id, session_name, region=None):
+def assume_role(root_session, acccount_id, region=None):
+    sts = root_session.client('sts')
+    session_name = get_role_session_name(sts)
     logger.debug(
-        "Assuming role arn:aws:iam::{}:role/admin over session {}".format(
+        "Assuming role arn:aws:iam::{}:role/admin with session {}".format(
             acccount_id, session_name
         )
     )
-    sts = root_session.client('sts')
     response = sts.assume_role(
         RoleArn='arn:aws:iam::{}:role/admin'.format(acccount_id),
         RoleSessionName=session_name,

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -1,6 +1,6 @@
 import json
 from collections import namedtuple
-from re import DOTALL, match, sub
+from re import DOTALL, match
 from subprocess import CalledProcessError, check_output
 
 import yaml
@@ -96,16 +96,9 @@ def _validate_email(email):
         )
 
 
-def get_role_session_name(env):
-    if 'JOB_NAME' in env:
-        _validate_job_name(env['JOB_NAME'])
-        unsafe_session_name = env['JOB_NAME']
-    elif 'EMAIL' in env:
-        _validate_email(env['EMAIL'])
-        unsafe_session_name = env['EMAIL']
-    else:
-        raise NoJobNameOrEmailError()
-    return sub(r'[^\w+=,.@-]+', '-', unsafe_session_name)[:64]
+def get_role_session_name(sts_client):
+    caller_response = sts_client.get_caller_identity()
+    return caller_response.get('UserId')
 
 
 def get_component_name(component_name):

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -1,6 +1,5 @@
 import json
 from collections import namedtuple
-from re import DOTALL, match
 from subprocess import CalledProcessError, check_output
 
 import yaml
@@ -23,10 +22,6 @@ class InvalidEmailError(UserFacingError):
 
 class InvalidURLError(UserFacingError):
     pass
-
-
-class NoJobNameOrEmailError(UserFacingFixedMessageError):
-    _message = 'JOB_NAME or EMAIL must be set'
 
 
 class NoGitRemoteError(UserFacingFixedMessageError):
@@ -81,20 +76,6 @@ def env_with_aws_credetials(env, boto_session):
         'AWS_DEFAULT_REGION': boto_session.region_name,
     })
     return result
-
-
-def _validate_job_name(job_name):
-    if len(job_name) < 6:
-        raise JobNameTooShortError(
-            'JOB_NAME must be at least 6 characters', job_name
-        )
-
-
-def _validate_email(email):
-    if not match(r'.+@([\w-]+\.)+\w+$', email, DOTALL):
-        raise InvalidEmailError(
-            'EMAIL does not contain a valid email address', email
-        )
 
 
 def get_role_session_name(sts_client):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -92,9 +92,7 @@ class TestAssumeRole(unittest.TestCase):
 
         mock_sts = Mock()
         user_id = 'foo'
-        mock_sts.get_caller_identity.return_value = {
-            u'UserId': user_id,
-        }
+        mock_sts.get_caller_identity.return_value = {u'UserId': user_id}
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',
@@ -138,9 +136,7 @@ class TestAssumeRole(unittest.TestCase):
 
         mock_sts = Mock()
         user_id = 'foo'
-        mock_sts.get_caller_identity.return_value = {
-            u'UserId': user_id,
-        }
+        mock_sts.get_caller_identity.return_value = {u'UserId': user_id}
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -91,6 +91,10 @@ class TestAssumeRole(unittest.TestCase):
         MockSession.return_value = mock_session
 
         mock_sts = Mock()
+        user_id = 'foo'
+        mock_sts.get_caller_identity.return_value = {
+            u'UserId': user_id,
+        }
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',
@@ -107,16 +111,14 @@ class TestAssumeRole(unittest.TestCase):
         mock_root_session.client.return_value = mock_sts
 
         account_id = 123456789
-        session_name = 'dummy-session-name'
-        session = config.assume_role(
-            mock_root_session, account_id, session_name
-        )
+        session = config.assume_role(mock_root_session, account_id)
+
         assert session is mock_session
 
         mock_root_session.client.assert_called_once_with('sts')
         mock_sts.assume_role.assert_called_once_with(
             RoleArn='arn:aws:iam::{}:role/admin'.format(account_id),
-            RoleSessionName=session_name,
+            RoleSessionName=user_id,
         )
         MockSession.assert_called_once_with(
             'dummy-access-key-id',
@@ -135,6 +137,10 @@ class TestAssumeRole(unittest.TestCase):
         MockSession.return_value = mock_session
 
         mock_sts = Mock()
+        user_id = 'foo'
+        mock_sts.get_caller_identity.return_value = {
+            u'UserId': user_id,
+        }
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',
@@ -151,16 +157,15 @@ class TestAssumeRole(unittest.TestCase):
         mock_root_session.client.return_value = mock_sts
 
         account_id = 123456789
-        session_name = 'dummy-session-name'
         session = config.assume_role(
-            mock_root_session, account_id, session_name, 'us-west-4',
+            mock_root_session, account_id, region='us-west-4',
         )
         assert session is mock_session
 
         mock_root_session.client.assert_called_once_with('sts')
         mock_sts.assume_role.assert_called_once_with(
             RoleArn='arn:aws:iam::{}:role/admin'.format(account_id),
-            RoleSessionName=session_name,
+            RoleSessionName=user_id,
         )
         MockSession.assert_called_once_with(
             'dummy-access-key-id',

--- a/test/test_integration_cli.py
+++ b/test/test_integration_cli.py
@@ -14,7 +14,6 @@ import yaml
 BotoCreds = namedtuple('BotoCreds', ['access_key', 'secret_key', 'token'])
 
 
-@patch.dict('cdflow_commands.cli.os.environ', {'JOB_NAME': 'dummy-job-name'})
 @patch('cdflow_commands.secrets.credstash')
 @patch('cdflow_commands.release.os')
 @patch('cdflow_commands.release.ZipFile')
@@ -247,7 +246,6 @@ class TestDeployCLI(unittest.TestCase):
         )
 
 
-@patch.dict('cdflow_commands.cli.os.environ', {'JOB_NAME': 'dummy-job-name'})
 @patch('cdflow_commands.destroy.check_call')
 @patch('cdflow_commands.destroy.time')
 @patch('cdflow_commands.cli.rmtree')

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -78,8 +78,6 @@ class TestReleaseCLI(unittest.TestCase):
         mock_session.client.return_value = mock_ecr_client
         Session_from_config.return_value = mock_session
 
-        mock_os.environ = {'JOB_NAME': 'dummy-job-name'}
-
         mock_sts = Mock()
         user_id = 'foo'
         mock_sts.get_caller_identity.return_value = {u'UserId': user_id}
@@ -210,8 +208,6 @@ class TestReleaseCLI(unittest.TestCase):
         mock_session = Mock()
         mock_session.client.return_value = mock_ecr_client
         Session_from_config.return_value = mock_session
-
-        mock_os.environ = {'JOB_NAME': 'dummy-job-name'}
 
         mock_sts = Mock()
         mock_sts.assume_role.return_value = {

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -81,6 +81,8 @@ class TestReleaseCLI(unittest.TestCase):
         mock_os.environ = {'JOB_NAME': 'dummy-job-name'}
 
         mock_sts = Mock()
+        user_id = 'foo'
+        mock_sts.get_caller_identity.return_value = {u'UserId': user_id}
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',
@@ -133,7 +135,7 @@ class TestReleaseCLI(unittest.TestCase):
 
         mock_sts.assume_role.assert_called_once_with(
             RoleArn='arn:aws:iam::123456789:role/admin',
-            RoleSessionName=mock_os.environ['JOB_NAME'],
+            RoleSessionName=user_id,
         )
 
         check_call.assert_any_call([

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -66,8 +66,6 @@ class TestReleaseCLI(unittest.TestCase):
         }
         mock_root_session.resource.return_value = mock_s3_resource
 
-        mock_os.environ = {'JOB_NAME': 'dummy-job-name'}
-
         mock_sts = Mock()
         mock_sts.assume_role.return_value = {
             'Credentials': {

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -106,10 +106,6 @@ class TestReleaseCLI(unittest.TestCase):
         }
         mock_root_session.client.return_value = mock_sts
 
-        mock_os.environ = {
-            'JOB_NAME': 'dummy-job-name'
-        }
-
         S3BucketFactory.return_value.get_bucket_name.return_value \
             = 'lambda-bucket'
 


### PR DESCRIPTION
Fetch the role session name from STS - there's little value in fetching the role name from the environment so we may as well fetch it from STS as that can't be overridden.


