### PR TITLE
Replace illegal characters in user id from STS

### DIFF
--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -1,5 +1,6 @@
 import json
 from collections import namedtuple
+import re
 from subprocess import CalledProcessError, check_output
 
 import yaml
@@ -10,6 +11,9 @@ from cdflow_commands.exceptions import (
     UserFacingError, UserFacingFixedMessageError
 )
 from cdflow_commands.logger import logger
+
+
+ILLEGAL_CHARACTERS = '[^\w+=,.@-]+'
 
 
 class JobNameTooShortError(UserFacingError):
@@ -80,7 +84,8 @@ def env_with_aws_credetials(env, boto_session):
 
 def get_role_session_name(sts_client):
     caller_response = sts_client.get_caller_identity()
-    return caller_response.get('UserId')
+    user_id = caller_response.get('UserId')
+    return re.sub(ILLEGAL_CHARACTERS, '-', user_id)
 
 
 def get_component_name(component_name):

--- a/test/test_integration_cli.py
+++ b/test/test_integration_cli.py
@@ -51,6 +51,7 @@ class TestDeployCLI(unittest.TestCase):
         _open.return_value.__enter__.return_value = mock_metadata_file
 
         mock_sts_client = Mock()
+        mock_sts_client.get_caller_identity.return_value = {'UserId': 'foo'}
         mock_sts_client.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key',
@@ -275,6 +276,7 @@ class TestDestroyCLI(unittest.TestCase):
         _open.return_value.__enter__.return_value = mock_metadata_file
 
         mock_sts_client = Mock()
+        mock_sts_client.get_caller_identity.return_value = {'UserId': 'foo'}
         mock_sts_client.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key',

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -210,6 +210,7 @@ class TestReleaseCLI(unittest.TestCase):
         Session_from_config.return_value = mock_session
 
         mock_sts = Mock()
+        mock_sts.get_caller_identity.return_value = {'UserId': 'foo'}
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -67,6 +67,7 @@ class TestReleaseCLI(unittest.TestCase):
         mock_root_session.resource.return_value = mock_s3_resource
 
         mock_sts = Mock()
+        mock_sts.get_caller_identity.return_value = {'UserId': 'foo'}
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -91,6 +91,7 @@ class TestReleaseCLI(unittest.TestCase):
         Session_from_config.return_value = mock_session
 
         mock_sts = Mock()
+        mock_sts.get_caller_identity.return_value = {'UserId': 'foo'}
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',


### PR DESCRIPTION
The user id we get back from STS might not be legal for using as the role name for a new assumed session so replace anything that is unpalatable.