### PR TITLE
Support multiple account aliases in scheme

### DIFF
--- a/cdflow_commands/account.py
+++ b/cdflow_commands/account.py
@@ -75,16 +75,16 @@ class AccountScheme:
             in raw_scheme['accounts'].items()
         }
 
-        environment_value_types = [
+        environment_value_types = (
             type(a) for a in raw_scheme['environments'].values()
-        ]
+        )
         multiple_account_deploys = False
 
-        if all([t == str for t in environment_value_types]):
+        if all(t is str for t in environment_value_types):
             environment_mapping = cls._get_env_mapping(
                 raw_scheme, accounts
             )
-        elif all([t == dict for t in environment_value_types]):
+        elif all(t is dict for t in environment_value_types):
             multiple_account_deploys = True
             environment_mapping = \
                 cls._get_multiple_account_deploys_env_mapping(

--- a/cdflow_commands/account.py
+++ b/cdflow_commands/account.py
@@ -121,3 +121,17 @@ class AccountScheme:
                 'multiple account deploy'
             )
         return self._environment_mapping[environment]
+
+    def account_role_mapping(self, environment):
+        if not self.multiple_account_deploys:
+            raise Exception(
+                'account_role_mapping not support when not a '
+                'multiple account deploy'
+            )
+        return {
+            prefix: "arn:aws:iam::{}:role/{}".format(
+                self._environment_mapping[environment][prefix].id,
+                self._environment_mapping[environment][prefix].role
+            )
+            for prefix in self._environment_mapping[environment]
+        }

--- a/cdflow_commands/account.py
+++ b/cdflow_commands/account.py
@@ -15,22 +15,17 @@ class AccountScheme:
 
     def __init__(
         self, accounts, release_account, release_bucket,
-        default_region, environment_mapping
+        default_region, environment_mapping, multiple_account_deploys
     ):
         self.accounts = accounts
         self.release_account = release_account
         self.release_bucket = release_bucket
         self.default_region = default_region
         self._environment_mapping = environment_mapping
+        self.multiple_account_deploys = multiple_account_deploys
 
     @classmethod
-    def create(cls, raw_scheme):
-        accounts = {
-            alias: Account(alias, account['id'], account['role'])
-            for alias, account
-            in raw_scheme['accounts'].items()
-        }
-
+    def _get_env_mapping(cls, raw_scheme, accounts):
         default_env_alias = raw_scheme['environments'].get(cls.DEFAULT_ENV_KEY)
 
         environment_mapping = {
@@ -43,6 +38,60 @@ class AccountScheme:
             environment_mapping = defaultdict(
                 lambda: default_env, environment_mapping
             )
+        return environment_mapping
+
+    @classmethod
+    def _get_multiple_account_deploys_env_mapping(cls, raw_scheme, accounts):
+        default_env_aliases = raw_scheme['environments'].get(
+            cls.DEFAULT_ENV_KEY
+        )
+
+        environment_mapping = {
+            env: {
+                prefix: accounts[raw_scheme['environments'][env][prefix]]
+                for prefix in raw_scheme['environments'][env]
+            }
+            for env in raw_scheme['environments']
+        }
+
+        if default_env_aliases:
+            default_env = {
+                prefix: accounts[
+                    raw_scheme['environments'][cls.DEFAULT_ENV_KEY][prefix]
+                ]
+                for prefix
+                in raw_scheme['environments'][cls.DEFAULT_ENV_KEY]
+            }
+            environment_mapping = defaultdict(
+                lambda: default_env, environment_mapping
+            )
+        return environment_mapping
+
+    @classmethod
+    def create(cls, raw_scheme):
+        accounts = {
+            alias: Account(alias, account['id'], account['role'])
+            for alias, account
+            in raw_scheme['accounts'].items()
+        }
+
+        environment_value_types = [
+            type(a) for a in raw_scheme['environments'].values()
+        ]
+        multiple_account_deploys = False
+
+        if all([t == str for t in environment_value_types]):
+            environment_mapping = cls._get_env_mapping(
+                raw_scheme, accounts
+            )
+        elif all([t == dict for t in environment_value_types]):
+            multiple_account_deploys = True
+            environment_mapping = \
+                cls._get_multiple_account_deploys_env_mapping(
+                    raw_scheme, accounts
+                )
+        else:
+            raise Exception('mixed environment types in account scheme')
 
         return AccountScheme(
             set(accounts.values()),
@@ -50,6 +99,7 @@ class AccountScheme:
             raw_scheme['release-bucket'],
             raw_scheme['default-region'],
             environment_mapping,
+            multiple_account_deploys
         )
 
     @property
@@ -57,4 +107,17 @@ class AccountScheme:
         return [account.id for account in self.accounts]
 
     def account_for_environment(self, environment):
+        if self.multiple_account_deploys:
+            raise Exception(
+                'account_for_environment not suported for '
+                'multiple account deploys'
+            )
+        return self._environment_mapping[environment]
+
+    def accounts_for_environment(self, environment):
+        if not self.multiple_account_deploys:
+            raise Exception(
+                'accounts_for_environment not support when not a '
+                'multiple account deploy'
+            )
         return self._environment_mapping[environment]

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -126,9 +126,12 @@ def run_deploy(
     version = args['<version>']
     account_id = account_scheme.account_for_environment(environment).id
 
-    deploy_account_session = assume_role(
-        root_session, account_id, account_scheme.default_region,
-    )
+    if account_scheme.multiple_account_deploys:
+        deploy_account_session = root_session
+    else:
+        deploy_account_session = assume_role(
+            root_session, account_id, account_scheme.default_region,
+        )
 
     with fetch_release(
         release_account_session, account_scheme.release_bucket,

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -4,7 +4,7 @@ cdflow
 Create and manage software services using continuous delivery.
 
 Usage:
-    cdflow release --platform-config <platform_config> <version> [options]
+    cdflow release (--platform-config <platform_config>)... <version> [options]
     cdflow deploy <environment> <version> [options]
     cdflow destroy <environment> [options]
 
@@ -97,7 +97,7 @@ def run_release(release_account_session, account_scheme, manifest, args):
     release = Release(
         boto_session=release_account_session,
         release_bucket=account_scheme.release_bucket,
-        platform_config_path=args['<platform_config>'],
+        platform_config_paths=args['<platform_config>'],
         version=args['<version>'],
         commit=commit,
         component_name=get_component_name(args['--component']),

--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -59,12 +59,12 @@ def format_release_key(component_name, version):
 class Release:
 
     def __init__(
-        self, boto_session, release_bucket, platform_config_path, commit,
+        self, boto_session, release_bucket, platform_config_paths, commit,
         version, component_name, team
     ):
         self.boto_session = boto_session
         self._release_bucket = release_bucket
-        self._platform_config_path = platform_config_path
+        self._platform_config_paths = platform_config_paths
         self._commit = commit
         self._team = team
         self.version = version
@@ -144,10 +144,14 @@ class Release:
 
     def _copy_platform_config_files(self, base_dir):
         path_in_release = '{}/{}'.format(base_dir, PLATFORM_CONFIG_BASE_PATH)
-        logger.debug('Copying {} to {}'.format(
-            self._platform_config_path, path_in_release
-        ))
-        copytree(self._platform_config_path, path_in_release)
+        for platform_config_path in self._platform_config_paths:
+            logger.debug('Copying {} to {}'.format(
+                platform_config_path, path_in_release
+            ))
+            copytree(
+                platform_config_path, path_in_release,
+                ignore=['.git']
+            )
 
     def _copy_app_config_files(self, base_dir):
         path_in_release = '{}/{}'.format(base_dir, CONFIG_BASE_PATH)

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -44,6 +44,7 @@ class TestDeploy(unittest.TestCase):
         secrets = fixtures['secrets']
 
         account_scheme = MagicMock(spec=AccountScheme)
+        account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
         account = MagicMock(spec=Account)
         account.alias = account_alias
@@ -133,6 +134,7 @@ class TestDeploy(unittest.TestCase):
         secrets = fixtures['secrets']
 
         account_scheme = MagicMock(spec=AccountScheme)
+        account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
         account = MagicMock(spec=Account)
         account.alias = account_alias
@@ -203,6 +205,7 @@ class TestDeploy(unittest.TestCase):
         secrets = fixtures['secrets']
 
         account_scheme = MagicMock(spec=AccountScheme)
+        account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
         account = MagicMock(spec=Account)
         account.alias = account_alias
@@ -292,6 +295,7 @@ class TestDeploy(unittest.TestCase):
         secrets = fixtures['secrets']
 
         account_scheme = MagicMock(spec=AccountScheme)
+        account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
         account = MagicMock(spec=Account)
         account.alias = account_alias
@@ -376,6 +380,7 @@ class TestDeploy(unittest.TestCase):
         secrets = fixtures['secrets']
 
         account_scheme = MagicMock(spec=AccountScheme)
+        account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
         account = MagicMock(spec=Account)
         account.alias = account_alias

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -2,9 +2,13 @@ import unittest
 from collections import namedtuple
 from contextlib import ExitStack
 from string import ascii_letters, digits
+from itertools import chain
+import json
 
 from hypothesis import given
-from hypothesis.strategies import dictionaries, fixed_dictionaries, text
+from hypothesis.strategies import (
+    dictionaries, fixed_dictionaries, text, sampled_from
+)
 from mock import patch, Mock, MagicMock
 
 from cdflow_commands.account import AccountScheme, Account
@@ -17,6 +21,12 @@ BotoCredentials = namedtuple(
 
 
 ALNUM = ascii_letters + digits
+
+
+def create_mock_account(alias):
+    account = MagicMock(spec=Account)
+    account.alias = alias
+    return account
 
 
 class TestDeploy(unittest.TestCase):
@@ -46,9 +56,8 @@ class TestDeploy(unittest.TestCase):
         account_scheme = MagicMock(spec=AccountScheme)
         account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
-        account = MagicMock(spec=Account)
-        account.alias = account_alias
-        account_scheme.account_for_environment.return_value = account
+        account_scheme.account_for_environment.return_value = \
+            create_mock_account(account_alias)
 
         boto_session = Mock()
         boto_session.region_name = aws_region
@@ -136,9 +145,8 @@ class TestDeploy(unittest.TestCase):
         account_scheme = MagicMock(spec=AccountScheme)
         account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
-        account = MagicMock(spec=Account)
-        account.alias = account_alias
-        account_scheme.account_for_environment.return_value = account
+        account_scheme.account_for_environment.return_value = \
+            create_mock_account(account_alias)
 
         boto_session = Mock()
         boto_session.region_name = aws_region
@@ -207,9 +215,8 @@ class TestDeploy(unittest.TestCase):
         account_scheme = MagicMock(spec=AccountScheme)
         account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
-        account = MagicMock(spec=Account)
-        account.alias = account_alias
-        account_scheme.account_for_environment.return_value = account
+        account_scheme.account_for_environment.return_value = \
+            create_mock_account(account_alias)
 
         boto_session = Mock()
         boto_session.region_name = aws_region
@@ -297,9 +304,8 @@ class TestDeploy(unittest.TestCase):
         account_scheme = MagicMock(spec=AccountScheme)
         account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
-        account = MagicMock(spec=Account)
-        account.alias = account_alias
-        account_scheme.account_for_environment.return_value = account
+        account_scheme.account_for_environment.return_value = \
+            create_mock_account(account_alias)
 
         boto_session = Mock()
         boto_session.region_name = aws_region
@@ -382,9 +388,8 @@ class TestDeploy(unittest.TestCase):
         account_scheme = MagicMock(spec=AccountScheme)
         account_scheme.multiple_account_deploys = False
         account_scheme.default_region = aws_region
-        account = MagicMock(spec=Account)
-        account.alias = account_alias
-        account_scheme.account_for_environment.return_value = account
+        account_scheme.account_for_environment.return_value = \
+            create_mock_account(account_alias)
 
         boto_session = Mock()
         boto_session.region_name = aws_region
@@ -437,6 +442,114 @@ class TestDeploy(unittest.TestCase):
                     '-var-file', secret_file_path,
                     '-out', 'plan-{}'.format(utcnow),
                     '-var-file', 'config/common.json',
+                    'infra',
+                ],
+                cwd=release_path,
+                env={
+                    'AWS_ACCESS_KEY_ID': credentials.access_key,
+                    'AWS_SECRET_ACCESS_KEY': credentials.secret_key,
+                    'AWS_SESSION_TOKEN': credentials.token,
+                    'AWS_DEFAULT_REGION': aws_region,
+                }
+            )
+
+    @given(fixed_dictionaries({
+        'environment': text(alphabet=ALNUM),
+        'release_path': text(alphabet=ALNUM),
+        'roles_by_account_prefix': dictionaries(
+            keys=text(alphabet=ALNUM),
+            values=text(alphabet=ALNUM),
+            min_size=1,
+        ),
+        'account_postfix': sampled_from(['dev', 'prod']),
+        'utcnow': text(alphabet=digits),
+        'access_key': text(alphabet=ALNUM),
+        'secret_key': text(alphabet=ALNUM),
+        'token': text(alphabet=ALNUM),
+        'aws_region': text(alphabet=ALNUM),
+        'secrets': dictionaries(keys=text(), values=text()),
+    }))
+    def test_account_role_mappings(self, fixtures):
+        environment = fixtures['environment']
+        release_path = fixtures['release_path']
+        roles_by_account_prefix = fixtures['roles_by_account_prefix']
+        account_postfix = fixtures['account_postfix']
+        utcnow = fixtures['utcnow']
+        access_key = fixtures['access_key']
+        secret_key = fixtures['secret_key']
+        token = fixtures['token']
+        aws_region = fixtures['aws_region']
+        secrets = fixtures['secrets']
+
+        account_scheme = MagicMock(spec=AccountScheme)
+        account_scheme.multiple_account_deploys = True
+        account_scheme.default_region = aws_region
+
+        account_scheme.accounts_for_environment.return_value = [
+            create_mock_account(account_prefix + account_postfix)
+            for account_prefix in roles_by_account_prefix
+        ]
+
+        account_scheme.account_role_mapping.return_value \
+            = roles_by_account_prefix
+
+        boto_session = Mock()
+        boto_session.region_name = aws_region
+        credentials = BotoCredentials(access_key, secret_key, token)
+        boto_session.get_credentials.return_value = credentials
+
+        deploy = Deploy(
+            environment, release_path, secrets, account_scheme, boto_session,
+        )
+
+        with ExitStack() as stack:
+            path_exists = stack.enter_context(
+                patch('cdflow_commands.deploy.path.exists')
+            )
+            check_call = stack.enter_context(
+                patch('cdflow_commands.deploy.check_call')
+            )
+            NamedTemporaryFile = stack.enter_context(
+                patch('cdflow_commands.deploy.NamedTemporaryFile')
+            )
+            mock_os = stack.enter_context(patch('cdflow_commands.deploy.os'))
+            time = stack.enter_context(
+                patch('cdflow_commands.deploy.time')
+            )
+
+            time.return_value = utcnow
+
+            secret_file_path = NamedTemporaryFile.return_value.__enter__\
+                .return_value.name
+
+            mock_os.environ = {}
+
+            path_exists.return_value = False
+
+            deploy.run()
+
+            def flatten(x):
+                return list(chain(*x))
+
+            check_call.assert_any_call(
+                [
+                    'terraform', 'plan', '-input=false',
+                    '-var', 'env={}'.format(environment),
+                    '-var-file', 'release.json',
+                ] + flatten([
+                    (
+                        '-var-file', 'platform-config/{}/{}.json'.format(
+                            account_prefix + account_postfix,
+                            boto_session.region_name
+                        )
+                    )
+                    for account_prefix in roles_by_account_prefix
+                ]) + [
+                    '-var-file', secret_file_path,
+                    '-out', 'plan-{}'.format(utcnow),
+                    '-var', 'accounts={}'.format(json.dumps(
+                        roles_by_account_prefix
+                    )),
                     'infra',
                 ],
                 cwd=release_path,

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -23,7 +23,7 @@ class TestRelease(unittest.TestCase):
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path=ANY, commit=ANY, version=version,
+            platform_config_paths=[ANY], commit=ANY, version=version,
             component_name=ANY, team=ANY
         )
 
@@ -36,7 +36,7 @@ class TestRelease(unittest.TestCase):
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path=ANY, commit=ANY, version=ANY,
+            platform_config_paths=[ANY], commit=ANY, version=ANY,
             component_name=component_name, team=ANY
         )
 
@@ -67,7 +67,7 @@ class TestReleaseArchive(unittest.TestCase):
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path=ANY,
+            platform_config_paths=[ANY],
             commit='dummy',
             version='dummy-version',
             component_name='dummy-component',
@@ -102,11 +102,14 @@ class TestReleaseArchive(unittest.TestCase):
         # Given
         release_plugin = Mock()
         release_plugin.create.return_value = {}
-        platform_config_path = 'test-platform-config-path'
+        platform_config_paths = [
+            'test-platform-config-path-a',
+            'test-platform-config-path-b',
+        ]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path=platform_config_path, commit='dummy',
+            platform_config_paths=platform_config_paths, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
         )
@@ -117,11 +120,14 @@ class TestReleaseArchive(unittest.TestCase):
         release.create(release_plugin)
 
         # Then
-        copytree.assert_any_call(
-            platform_config_path, '{}/{}-{}/platform-config'.format(
-                temp_dir, 'dummy-component', 'dummy-version'
+        for platform_config_path in platform_config_paths:
+            copytree.assert_any_call(
+                platform_config_path,
+                '{}/{}-{}/platform-config'.format(
+                    temp_dir, 'dummy-component', 'dummy-version'
+                ),
+                ignore=['.git']
             )
-        )
 
     @patch('cdflow_commands.release.mkdir')
     @patch('cdflow_commands.release.open')
@@ -137,11 +143,11 @@ class TestReleaseArchive(unittest.TestCase):
         # Given
         release_plugin = Mock()
         release_plugin.create.return_value = {}
-        platform_config_path = 'test-platform-config-path'
+        platform_config_paths = ['test-platform-config-path']
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path=platform_config_path, commit='dummy',
+            platform_config_paths=platform_config_paths, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
         )
@@ -173,11 +179,11 @@ class TestReleaseArchive(unittest.TestCase):
         # Given
         release_plugin = Mock()
         release_plugin.create.return_value = {}
-        platform_config_path = 'test-platform-config-path'
+        platform_config_paths = ['test-platform-config-path']
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path=platform_config_path, commit='dummy',
+            platform_config_paths=platform_config_paths, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
         )
@@ -207,11 +213,11 @@ class TestReleaseArchive(unittest.TestCase):
         # Given
         release_plugin = Mock()
         release_plugin.create.return_value = {}
-        platform_config_path = 'test-platform-config-path'
+        platform_config_paths = 'test-platform-config-path'
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path=platform_config_path, commit='dummy',
+            platform_config_paths=platform_config_paths, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
         )
@@ -251,7 +257,7 @@ class TestReleaseArchive(unittest.TestCase):
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path='platform-config',
+            platform_config_paths='platform-config',
             commit=commit,
             version=version,
             component_name=component_name,
@@ -314,7 +320,7 @@ class TestReleaseArchive(unittest.TestCase):
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_path='test-platform-config-path',
+            platform_config_paths='test-platform-config-path',
             commit=commit,
             version=version,
             component_name=component_name,
@@ -362,7 +368,7 @@ class TestReleaseArchive(unittest.TestCase):
         release = Release(
             boto_session=mock_session,
             release_bucket=release_bucket,
-            platform_config_path='test-platform-config-path',
+            platform_config_paths='test-platform-config-path',
             commit=commit,
             version=version,
             component_name=component_name,


### PR DESCRIPTION
This lays the ground work for supporting multiple accounts in a single
deploy. It adds support for having each environment be a mapping from
account prefix to account alias, so that we can pass a mapping of
account prefixes to IAM role ARNs into the deploy.

JIRA: PLAT-1152