### PR TITLE
Fix platform config copy

### DIFF
--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -2,8 +2,8 @@ from contextlib import contextmanager
 from io import BytesIO
 import json
 import os
-from os import chmod, getcwd, path, mkdir, listdir
-from os.path import exists, isdir, isfile
+from os import chmod, getcwd, path, mkdir, makedirs, listdir
+from os.path import isdir, isfile
 from shutil import copytree, make_archive, copyfile
 import shutil
 from tempfile import TemporaryDirectory
@@ -59,8 +59,7 @@ def format_release_key(component_name, version):
 
 
 def _copy_platform_config_files(source_dir, dest_dir):
-    if not exists(dest_dir):
-        mkdir(dest_dir)
+    makedirs(dest_dir, exist_ok=True)
     for config in listdir(source_dir):
         source = os.path.join(source_dir, config)
         dest = os.path.join(dest_dir, config)

--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -2,12 +2,14 @@ from contextlib import contextmanager
 from io import BytesIO
 import json
 import os
-from os import chmod, getcwd, path, mkdir
-from shutil import copytree, make_archive, ignore_patterns
+from os import chmod, getcwd, path, mkdir, listdir
+from os.path import exists, isdir, isfile
+from shutil import copytree, make_archive, copyfile
 import shutil
 from tempfile import TemporaryDirectory
 from time import time
 from zipfile import ZipFile
+from re import match, search
 
 from cdflow_commands.constants import (
     CONFIG_BASE_PATH, INFRASTRUCTURE_DEFINITIONS_PATH,
@@ -56,6 +58,27 @@ def format_release_key(component_name, version):
     return '{}/{}-{}.zip'.format(component_name, component_name, version)
 
 
+def _copy_platform_config_files(source_dir, dest_dir):
+    if not exists(dest_dir):
+        mkdir(dest_dir)
+    for config in listdir(source_dir):
+        source = os.path.join(source_dir, config)
+        dest = os.path.join(dest_dir, config)
+        if search(r'\.json$', source) and isfile(source):
+            copyfile(source, dest)
+
+
+def _copy_platform_config(source_dir, dest_dir):
+    for item in listdir(source_dir):
+        if not match(r'^\w+$', item):
+            continue
+        source = os.path.join(source_dir, item)
+        if not isdir(source):
+            continue
+        dest = os.path.join(dest_dir, item)
+        _copy_platform_config_files(source, dest)
+
+
 class Release:
 
     def __init__(
@@ -86,7 +109,7 @@ class Release:
                     {} not found - Add if you want to include environment \
                     configuration
                     """.format(CONFIG_BASE_PATH))
-            self._copy_platform_config_files(base_dir)
+            self._copy_platform_configs(base_dir)
             self._copy_infra_files(base_dir)
 
             extra_data = plugin.create()
@@ -142,16 +165,13 @@ class Release:
             TERRAFORM_BINARY, 'get', infra_dir
         ], cwd=base_dir)
 
-    def _copy_platform_config_files(self, base_dir):
+    def _copy_platform_configs(self, base_dir):
         path_in_release = '{}/{}'.format(base_dir, PLATFORM_CONFIG_BASE_PATH)
         for platform_config_path in self._platform_config_paths:
             logger.debug('Copying {} to {}'.format(
                 platform_config_path, path_in_release
             ))
-            copytree(
-                platform_config_path, path_in_release,
-                ignore=ignore_patterns('.git')
-            )
+            _copy_platform_config(platform_config_path, path_in_release)
 
     def _copy_app_config_files(self, base_dir):
         path_in_release = '{}/{}'.format(base_dir, CONFIG_BASE_PATH)

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -8,6 +8,7 @@ from mock import MagicMock, Mock, mock_open, patch
 import yaml
 
 
+@patch('cdflow_commands.release._copy_platform_config')
 @patch('cdflow_commands.cli.check_output')
 @patch('cdflow_commands.release.os')
 @patch('cdflow_commands.release.copytree')
@@ -26,7 +27,7 @@ class TestReleaseCLI(unittest.TestCase):
     def test_release_is_configured_and_created(
         self, check_call, check_output, mock_open, Session_from_config,
         Session_from_cli, rmtree, mock_os, mock_open_release, make_archive,
-        check_call_release, copytree, mock_os_release, check_output_cli,
+        check_call_release, copytree, mock_os_release, check_output_cli, _
     ):
         mock_metadata_file = MagicMock(spec=TextIOWrapper)
         metadata = {
@@ -157,7 +158,7 @@ class TestReleaseCLI(unittest.TestCase):
     def test_release_uses_component_name_from_origin(
         self, check_call, check_output, mock_open, Session_from_config,
         Session_from_cli, rmtree, mock_os, mock_open_release, make_archive,
-        check_call_release, copytree, mock_os_release, check_output_cli,
+        check_call_release, copytree, mock_os_release, check_output_cli, _
     ):
         mock_metadata_file = MagicMock(spec=TextIOWrapper)
         metadata = {

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -11,6 +11,7 @@ from cdflow_commands import cli
 
 class TestReleaseCLI(unittest.TestCase):
 
+    @patch('cdflow_commands.release._copy_platform_config')
     @patch('cdflow_commands.release.os')
     @patch('cdflow_commands.release.copytree')
     @patch('cdflow_commands.release.check_call')
@@ -26,7 +27,7 @@ class TestReleaseCLI(unittest.TestCase):
     def test_release_is_a_no_op(
         self, check_output, mock_open, Session_from_config, Session_from_cli,
         rmtree, mock_os, check_output_cli, mock_open_release, make_archive,
-        check_call_release, copytree, mock_os_release,
+        check_call_release, copytree, mock_os_release, _
     ):
         mock_metadata_file = MagicMock(spec=TextIOWrapper)
         metadata = {

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -12,6 +12,7 @@ from cdflow_commands.state import S3BucketFactory
 
 class TestReleaseCLI(unittest.TestCase):
 
+    @patch('cdflow_commands.release._copy_platform_config')
     @patch('cdflow_commands.cli.check_output')
     @patch('cdflow_commands.plugins.aws_lambda.ZipFile')
     @patch('cdflow_commands.plugins.aws_lambda.os')
@@ -34,7 +35,7 @@ class TestReleaseCLI(unittest.TestCase):
         self, check_output, mock_open_config, Session_from_config,
         Session_from_cli, rmtree, mock_os, mock_open_release, make_archive,
         check_call, copytree, mock_os_release, S3BucketFactory, mock_os_lambda,
-        ZipFile, check_output_cli,
+        ZipFile, check_output_cli, _
     ):
         # Given
         mock_metadata_file = MagicMock(spec=TextIOWrapper)

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -90,20 +90,20 @@ class TestReleaseArchive(unittest.TestCase):
             'terraform', 'get', '/cwd/infra',
         ], cwd='{}/{}-{}'.format(temp_dir, 'dummy-component', 'dummy-version'))
 
+    @patch('cdflow_commands.release.mkdir')
     @patch('cdflow_commands.release.open')
     @patch('cdflow_commands.release.check_call')
     @patch('cdflow_commands.release.make_archive')
     @patch('cdflow_commands.release.copytree')
     @patch('cdflow_commands.release.copyfile')
     @patch('cdflow_commands.release.isfile')
-    @patch('cdflow_commands.release.mkdir')
-    @patch('cdflow_commands.release.exists')
+    @patch('cdflow_commands.release.makedirs')
     @patch('cdflow_commands.release.isdir')
     @patch('cdflow_commands.release.listdir')
     @patch('cdflow_commands.release.TemporaryDirectory')
     def test_platform_config_added_to_release_bundle(
-        self, TemporaryDirectory, listdir, isdir, exists, mkdir, isfile,
-        copyfile, _1, _2, _3, _4
+        self, TemporaryDirectory, listdir, isdir, makedirs, isfile,
+        copyfile, _1, _2, _3, _4, _5
     ):
 
         # Given
@@ -131,9 +131,6 @@ class TestReleaseArchive(unittest.TestCase):
         }
         listdir.side_effect = lambda d: dirs[d]
         isdir.side_effect = lambda d: d in dirs
-        missing_dir = 'test-temp-dir/dummy-component-dummy-version/' \
-            'platform-config/alias2'
-        exists.side_effect = lambda d: d != missing_dir
         isfile.return_value = True
 
         # When
@@ -165,7 +162,21 @@ class TestReleaseArchive(unittest.TestCase):
             'test-temp-dir/dummy-component-dummy-version/'
             'platform-config/alias3/5.json',
         )
-        mkdir.assert_any_call(missing_dir)
+        makedirs.assert_any_call(
+            'test-temp-dir/dummy-component-dummy-version/'
+            'platform-config/alias1',
+            exist_ok=True
+        )
+        makedirs.assert_any_call(
+            'test-temp-dir/dummy-component-dummy-version/'
+            'platform-config/alias2',
+            exist_ok=True
+        )
+        makedirs.assert_any_call(
+            'test-temp-dir/dummy-component-dummy-version/'
+            'platform-config/alias3',
+            exist_ok=True
+        )
 
     @patch('cdflow_commands.release._copy_platform_config')
     @patch('cdflow_commands.release.mkdir')


### PR DESCRIPTION
Unfortunately copytree doesn't do the equivalent of `cp -r` - if the
destination exists it fails. In order to keep the behaviour of not
including the .git folder, this change copies the individual files only.