### PR TITLE
Add option to store state in release account

### DIFF
--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -36,6 +36,7 @@ Manifest = namedtuple('Manifest', [
         'account_scheme_url',
         'team',
         'type',
+        'terraform_state_in_release_account',
     ]
 )
 
@@ -47,6 +48,7 @@ def load_manifest():
             manifest_data['account-scheme-url'],
             manifest_data['team'],
             manifest_data['type'],
+            manifest_data.get('terraform-state-in-release-account', False),
         )
 
 

--- a/cdflow_commands/state.py
+++ b/cdflow_commands/state.py
@@ -1,5 +1,4 @@
 import atexit
-import os
 from hashlib import sha1
 from os import mkdir, unlink
 from os.path import abspath
@@ -9,7 +8,6 @@ from textwrap import dedent
 
 from botocore.exceptions import ClientError
 
-from cdflow_commands.config import env_with_aws_credetials
 from cdflow_commands.exceptions import CDFlowError
 from cdflow_commands.logger import logger
 from cdflow_commands.process import check_call
@@ -76,6 +74,7 @@ def initialise_terraform_backend(
         f'{boto_session.region_name}, {key}, {lock_table_name}'
     )
 
+    credentials = boto_session.get_credentials()
     check_call(
         [
             'terraform', 'init',
@@ -84,11 +83,11 @@ def initialise_terraform_backend(
             f'-backend-config=region={boto_session.region_name}',
             f'-backend-config=key={key}',
             f'-backend-config=lock_table={lock_table_name}',
+            f'-backend-config=access_key={credentials.access_key}',
+            f'-backend-config=secret_key={credentials.secret_key}',
+            f'-backend-config=token={credentials.token}',
         ],
         cwd=directory,
-        env=env_with_aws_credetials(
-            os.environ, boto_session
-        )
     )
 
     from_path_statefile = abspath(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -154,3 +154,69 @@ class TestMultiAccountDeploy(unittest.TestCase):
 
         # Then
         assert not assume_role.called
+
+
+class TestDeployStateInReleaseAccount(unittest.TestCase):
+
+    @patch('cdflow_commands.cli.assume_role')
+    @patch('cdflow_commands.cli.get_secrets')
+    @patch('cdflow_commands.cli.Deploy')
+    @patch('cdflow_commands.cli.get_component_name')
+    @patch('cdflow_commands.cli.fetch_release')
+    @patch('cdflow_commands.cli.initialise_terraform')
+    def test_role_not_assumed_for_multi_account_deploy(
+        self, initialise_terraform, fetch_release, _1, _2, _3, _4
+    ):
+        # Given
+        fetch_release.return_value.__enter__.return_value = 'dummy'
+        manifest = Mock()
+        manifest.terraform_state_in_release_account = True
+        release_account_session = Mock()
+
+        # When
+        args = {
+            '<environment>': ANY,
+            '<version>': ANY,
+            '--plan-only': False,
+            '--component': ANY
+        }
+        cli.run_deploy(Mock(), release_account_session, Mock(), manifest, args)
+
+        # Then
+        initialise_terraform.assert_called_once_with(
+            ANY, release_account_session, ANY, ANY
+        )
+
+
+class TestDestroyStateInReleaseAccount(unittest.TestCase):
+
+    @patch('cdflow_commands.cli.assume_role')
+    @patch('cdflow_commands.cli.get_secrets')
+    @patch('cdflow_commands.cli.Destroy')
+    @patch('cdflow_commands.cli.get_component_name')
+    @patch('cdflow_commands.cli.fetch_release')
+    @patch('cdflow_commands.cli.initialise_terraform')
+    def test_role_not_assumed_for_multi_account_deploy(
+        self, initialise_terraform, fetch_release, _1, _2, _3, _4
+    ):
+        # Given
+        fetch_release.return_value.__enter__.return_value = 'dummy'
+        manifest = Mock()
+        manifest.terraform_state_in_release_account = True
+        release_account_session = Mock()
+
+        # When
+        args = {
+            '<environment>': ANY,
+            '<version>': ANY,
+            '--plan-only': False,
+            '--component': ANY
+        }
+        cli.run_destroy(
+            Mock(), release_account_session, Mock(), manifest, args
+        )
+
+        # Then
+        initialise_terraform.assert_called_once_with(
+            ANY, release_account_session, ANY, ANY
+        )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -78,6 +78,28 @@ class TestLoadManifest(unittest.TestCase):
         assert manifest.account_scheme_url == fixtures['account-scheme-url']
         assert manifest.team == fixtures['team']
         assert manifest.type == fixtures['type']
+        assert manifest.terraform_state_in_release_account is False
+
+    def test_terraform_state_in_release_account(self):
+        # Given
+        mock_file = MagicMock(spec=TextIOWrapper)
+        mock_file.read.return_value = yaml.dump({
+            'account-scheme-url': 'dummy',
+            'team': 'dummy',
+            'type': 'dummy',
+            'terraform-state-in-release-account': True
+        })
+
+        with patch(
+            'cdflow_commands.config.open', new_callable=mock_open, create=True
+        ) as open_:
+            open_.return_value.__enter__.return_value = mock_file
+
+            # When
+            manifest = config.load_manifest()
+
+        # Then
+        assert manifest.terraform_state_in_release_account is True
 
 
 class TestAssumeRole(unittest.TestCase):

--- a/test/test_integration_cli.py
+++ b/test/test_integration_cli.py
@@ -164,8 +164,8 @@ class TestDeployCLI(unittest.TestCase):
 
         # Then
         check_call_state.assert_any_call(
-            ['terraform', 'init', ANY, ANY, ANY, ANY, ANY],
-            env=ANY, cwd=workdir+'/infra'
+            ['terraform', 'init', ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY],
+            cwd=workdir+'/infra'
         )
 
         check_call_deploy.assert_any_call(
@@ -384,8 +384,10 @@ class TestDestroyCLI(unittest.TestCase):
                 '-backend-config=region=us-north-4',
                 '-backend-config=key={}'.format(state_file_key),
                 '-backend-config=lock_table=terraform_locks',
+                '-backend-config=access_key=dummy-access-key-id',
+                '-backend-config=secret_key=dummy-secret-access-key',
+                '-backend-config=token=dummy-session-token',
             ],
-            env=ANY,
             cwd=ANY,
         )
 
@@ -428,8 +430,10 @@ class TestDestroyCLI(unittest.TestCase):
                 '-backend-config=region=us-north-4',
                 '-backend-config=key={}'.format(state_file_key),
                 '-backend-config=lock_table=terraform_locks',
+                '-backend-config=access_key={}'.format(aws_access_key_id),
+                '-backend-config=secret_key={}'.format(aws_secret_access_key),
+                '-backend-config=token={}'.format(aws_session_token),
             ],
-            env=ANY,
             cwd=ANY,
         )
 

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -628,8 +628,10 @@ class TestTerraformBackendConfig(unittest.TestCase):
                 f'-backend-config=region={boto_session.region_name}',
                 f'-backend-config=key={state_file_key}',
                 f'-backend-config=lock_table={lock_table_name}',
+                ANY,
+                ANY,
+                ANY,
             ],
-            env=ANY,
             cwd=directory
         )
 


### PR DESCRIPTION
This change adds the `terraform-state-in-release-account` boolean
option on the cdflow.yml manifest. This is needed when deploying to
multiple accounts - e.g. for the login-subscriber service - but more
than that, I see it as a valuable goal to have all of our terraform
state files in a single s3 bucket so we have a central inventory of all
of the AWS infrastructure owned by Acuris. This therefore proposes that
we migrate all services to set this flag before making it the default
and removing the flag altogether. This combined with having a shared
release account would achieve the goal of putting all of the state in
one place (moving state to a new release account should a service or
group of services transfer ownership to another organisation should
also be pretty easy).

JIRA: PLAT-1152