### PR TITLE
Add option to store secrets in release account

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -155,10 +155,15 @@ def run_deploy(
             terraform_session, environment, component_name,
         )
 
+        if manifest.secrets_in_release_account:
+            secrets_session = release_account_session
+        else:
+            secrets_session = deploy_account_session
+
         secrets = {
             'secrets': get_secrets(
                 environment, manifest.team,
-                component_name, deploy_account_session
+                component_name, secrets_session
             )
         }
 

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -37,6 +37,7 @@ Manifest = namedtuple('Manifest', [
         'team',
         'type',
         'terraform_state_in_release_account',
+        'secrets_in_release_account',
     ]
 )
 
@@ -49,6 +50,7 @@ def load_manifest():
             manifest_data['team'],
             manifest_data['type'],
             manifest_data.get('terraform-state-in-release-account', False),
+            manifest_data.get('secrets-in-release-account', False),
         )
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -79,6 +79,7 @@ class TestLoadManifest(unittest.TestCase):
         assert manifest.team == fixtures['team']
         assert manifest.type == fixtures['type']
         assert manifest.terraform_state_in_release_account is False
+        assert manifest.secrets_in_release_account is False
 
     def test_terraform_state_in_release_account(self):
         # Given
@@ -100,6 +101,27 @@ class TestLoadManifest(unittest.TestCase):
 
         # Then
         assert manifest.terraform_state_in_release_account is True
+
+    def test_secrets_in_release_account(self):
+        # Given
+        mock_file = MagicMock(spec=TextIOWrapper)
+        mock_file.read.return_value = yaml.dump({
+            'account-scheme-url': 'dummy',
+            'team': 'dummy',
+            'type': 'dummy',
+            'secrets-in-release-account': True
+        })
+
+        with patch(
+            'cdflow_commands.config.open', new_callable=mock_open, create=True
+        ) as open_:
+            open_.return_value.__enter__.return_value = mock_file
+
+            # When
+            manifest = config.load_manifest()
+
+        # Then
+        assert manifest.secrets_in_release_account is True
 
 
 class TestAssumeRole(unittest.TestCase):


### PR DESCRIPTION
This is to unblock the login-subscriber. Not sure whether the long term
direction should be to migrate to this, or to move all credstash
handling into the terraform and hence keep it in the deploy account.

JIRA: PLAT-1152