### PR TITLE
Don't set session token when there isn't one

### DIFF
--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -80,9 +80,12 @@ def env_with_aws_credetials(env, boto_session):
     result.update({
         'AWS_ACCESS_KEY_ID': credentials.access_key,
         'AWS_SECRET_ACCESS_KEY': credentials.secret_key,
-        'AWS_SESSION_TOKEN': credentials.token,
         'AWS_DEFAULT_REGION': boto_session.region_name,
     })
+    if credentials.token is not None:
+        result.update({
+            'AWS_SESSION_TOKEN': credentials.token,
+        })
     return result
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -516,3 +516,32 @@ class TestEnvWithAWSCredentials(unittest.TestCase):
             'AWS_SESSION_TOKEN': fixtures['token'],
             'AWS_DEFAULT_REGION': fixtures['region'],
         })
+
+    @given(fixed_dictionaries({
+        'access_key': text(),
+        'secret_key': text(),
+        'region': text(),
+    }))
+    def test_env_with_aws_credentials_root_account(self, fixtures):
+
+        # Given
+        session = Mock()
+        credentials = Mock()
+        session.get_credentials.return_value = credentials
+        credentials.access_key = fixtures['access_key']
+        credentials.secret_key = fixtures['secret_key']
+        credentials.token = None
+        session.region_name = fixtures['region']
+        env = {'existing': 'value'}
+
+        # When
+        result = config.env_with_aws_credetials(env, session)
+
+        # Then
+        self.assertEqual(env, {'existing': 'value'})
+        self.assertEqual(result, {
+            'existing': 'value',
+            'AWS_ACCESS_KEY_ID': fixtures['access_key'],
+            'AWS_SECRET_ACCESS_KEY': fixtures['secret_key'],
+            'AWS_DEFAULT_REGION': fixtures['region'],
+        })


### PR DESCRIPTION
Trying to set an environment variable to None doesn't work, so if the
session token isn't set (when it's the root account in jenkins) don't
set it.