### PR TITLE
Add support for tfstate-filename manifest key

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -153,6 +153,7 @@ def run_deploy(
         initialise_terraform(
             os.path.join(path_to_release, INFRASTRUCTURE_DEFINITIONS_PATH),
             terraform_session, environment, component_name,
+            manifest.tfstate_filename
         )
 
         if manifest.secrets_in_release_account:
@@ -193,7 +194,7 @@ def run_destroy(
 
     initialise_terraform(
         TERRAFORM_DESTROY_DEFINITION, terraform_session,
-        environment, component_name,
+        environment, component_name, manifest.tfstate_filename
     )
 
     destroy = Destroy(destroy_account_session)
@@ -208,7 +209,10 @@ def run_destroy(
 
     if not plan_only:
         logger.info('Destroying {} in {}'.format(component_name, environment))
-        remove_state(destroy_account_session, environment, component_name)
+        remove_state(
+            destroy_account_session, environment, component_name,
+            manifest.tfstate_filename
+        )
 
 
 def conditionally_set_debug(verbose):

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -36,6 +36,7 @@ Manifest = namedtuple('Manifest', [
         'account_scheme_url',
         'team',
         'type',
+        'tfstate_filename',
         'terraform_state_in_release_account',
         'secrets_in_release_account',
     ]
@@ -49,6 +50,7 @@ def load_manifest():
             manifest_data['account-scheme-url'],
             manifest_data['team'],
             manifest_data['type'],
+            manifest_data.get('tfstate-filename', 'terraform.tfstate'),
             manifest_data.get('terraform-state-in-release-account', False),
             manifest_data.get('secrets-in-release-account', False),
         )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -184,7 +184,7 @@ class TestDeployStateInReleaseAccount(unittest.TestCase):
 
         # Then
         initialise_terraform.assert_called_once_with(
-            ANY, release_account_session, ANY, ANY
+            ANY, release_account_session, ANY, ANY, ANY
         )
 
 
@@ -218,5 +218,5 @@ class TestDestroyStateInReleaseAccount(unittest.TestCase):
 
         # Then
         initialise_terraform.assert_called_once_with(
-            ANY, release_account_session, ANY, ANY
+            ANY, release_account_session, ANY, ANY, ANY
         )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -78,8 +78,30 @@ class TestLoadManifest(unittest.TestCase):
         assert manifest.account_scheme_url == fixtures['account-scheme-url']
         assert manifest.team == fixtures['team']
         assert manifest.type == fixtures['type']
+        assert manifest.tfstate_filename == 'terraform.tfstate'
         assert manifest.terraform_state_in_release_account is False
         assert manifest.secrets_in_release_account is False
+
+    def test_tfstate_filename(self):
+        # Given
+        mock_file = MagicMock(spec=TextIOWrapper)
+        mock_file.read.return_value = yaml.dump({
+            'account-scheme-url': 'dummy',
+            'team': 'dummy',
+            'type': 'dummy',
+            'tfstate-filename': 'test-tfstate-filename'
+        })
+
+        with patch(
+            'cdflow_commands.config.open', new_callable=mock_open, create=True
+        ) as open_:
+            open_.return_value.__enter__.return_value = mock_file
+
+            # When
+            manifest = config.load_manifest()
+
+        # Then
+        assert manifest.tfstate_filename == 'test-tfstate-filename'
 
     def test_terraform_state_in_release_account(self):
         # Given

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -547,7 +547,8 @@ terraform_backend_input = fixed_dictionaries({
         alphabet=ascii_lowercase + digits + '-', min_size=3, max_size=63
     ),
     'environment_name': text(min_size=1),
-    'component_name': text(min_size=1)
+    'component_name': text(min_size=1),
+    'tfstate_filename': text(min_size=1),
 })
 
 
@@ -562,6 +563,7 @@ class TestTerraformBackendConfig(unittest.TestCase):
         lock_table_name = terraform_backend_input['lock_table_name']
         environment_name = terraform_backend_input['environment_name']
         component_name = terraform_backend_input['component_name']
+        tfstate_filename = terraform_backend_input['tfstate_filename']
         boto_session = MagicMock(spec=Session)
 
         with ExitStack() as stack:
@@ -577,7 +579,7 @@ class TestTerraformBackendConfig(unittest.TestCase):
 
             initialise_terraform_backend(
                 directory, boto_session, bucket_name, lock_table_name,
-                environment_name, component_name
+                environment_name, component_name, tfstate_filename
             )
 
         NamedTemporaryFile.assert_called_once_with(
@@ -599,10 +601,11 @@ class TestTerraformBackendConfig(unittest.TestCase):
         lock_table_name = terraform_backend_input['lock_table_name']
         environment_name = terraform_backend_input['environment_name']
         component_name = terraform_backend_input['component_name']
+        tfstate_filename = terraform_backend_input['tfstate_filename']
         boto_session = MagicMock(spec=Session)
 
         state_file_key = (
-            f'{environment_name}/{component_name}/terraform.tfstate'
+            f'{environment_name}/{component_name}/{tfstate_filename}'
         )
 
         with ExitStack() as stack:
@@ -617,7 +620,7 @@ class TestTerraformBackendConfig(unittest.TestCase):
 
             initialise_terraform_backend(
                 directory, boto_session, bucket_name, lock_table_name,
-                environment_name, component_name
+                environment_name, component_name, tfstate_filename
             )
 
         check_call.assert_called_once_with(
@@ -642,6 +645,7 @@ class TestTerraformBackendConfig(unittest.TestCase):
         lock_table_name = terraform_backend_input['lock_table_name']
         environment_name = terraform_backend_input['environment_name']
         component_name = terraform_backend_input['component_name']
+        tfstate_filename = terraform_backend_input['tfstate_filename']
         boto_session = MagicMock(spec=Session)
 
         with ExitStack() as stack:
@@ -654,7 +658,7 @@ class TestTerraformBackendConfig(unittest.TestCase):
 
             initialise_terraform_backend(
                 directory, boto_session, bucket_name, lock_table_name,
-                environment_name, component_name
+                environment_name, component_name, tfstate_filename
             )
 
         move.assert_has_calls(
@@ -687,6 +691,9 @@ class TestTerraformBackendConfig(unittest.TestCase):
         component_name = (
             test_fixtures['terraform_backend_input']['component_name']
         )
+        tfstate_filename = (
+            test_fixtures['terraform_backend_input']['tfstate_filename']
+        )
 
         backend_config_file_name = (
             f'cdflow_backend_{test_fixtures["temp_file_name"]}.tf'
@@ -705,7 +712,7 @@ class TestTerraformBackendConfig(unittest.TestCase):
 
             initialise_terraform_backend(
                 directory, boto_session, bucket_name, lock_table_name,
-                environment_name, component_name
+                environment_name, component_name, tfstate_filename
             )
 
         atexit.register.assert_called_once_with(


### PR DESCRIPTION
When migrating older cdflow projects to new ones and trying to run the
new pipeline with new infrastructure definition in parallel, the deploy
finds the existing tfstate file and removes all of the infrastructure
(not very helpful). This change adds an optional `tfstate-filename` key
that chnages the last part of the key we use to store the tfstate file
in s3 so that the new infrastructure can coexist with the old, until we
are ready to move it to the default location.