### PR TITLE
Cleanup ECR repositories using AWS ECR Lifecycle policy

### DIFF
--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -33,6 +33,7 @@ class ReleasePlugin:
         if self._release.version:
             self._ensure_ecr_repo_exists()
             self._ensure_ecr_policy_set()
+            self._ensure_ecr_lifecycle_policy_set()
             self._docker_login()
             self._docker_push(self._image_name)
             self._docker_tag_latest()
@@ -115,6 +116,48 @@ class ReleasePlugin:
                 } for account_id in sorted(account_ids)]
             }, sort_keys=True)
         )
+
+    def _is_ecr_lifecycle_policy_not_set(self, account_id, component):
+        try:
+            self._boto_ecr_client.get_lifecycle_policy(
+                registryId=account_id,
+                repositoryName=component
+            )
+            return False
+        except ClientError as e:
+            if e.response['Error']['Code'] !=\
+                    'LifecyclePolicyNotFoundException':
+                raise
+            return True
+
+    def _ensure_ecr_lifecycle_policy_set(self):
+        if self._is_ecr_lifecycle_policy_not_set(
+            self._account_scheme.release_account.id,
+            self._release.component_name
+        ):
+            lifecycle_policy = json.dumps({
+                "rules": [
+                    {
+                        "rulePriority": 1,
+                        "description": "Keep 500 tagged images (we tag all images), expire all others", # noqa
+                        "selection": {
+                            "tagStatus": "tagged",
+                            "tagPrefixList": ["1", "2", "3", "4", "5", "6", "7", "8", "9"], # noqa
+                            "countType": "imageCountMoreThan",
+                            "countNumber": 500
+                        },
+                        "action": {
+                            "type": "expire"
+                        }
+                    }
+                ]
+            })
+
+            self._boto_ecr_client.put_lifecycle_policy(
+                registryId=self._account_scheme.release_account.id,
+                repositoryName=self._release.component_name,
+                lifecyclePolicyText=lifecycle_policy
+            )
 
     def _docker_login(self):
         response = self._boto_ecr_client.get_authorization_token()

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -288,7 +288,7 @@ class TestRelease(unittest.TestCase):
             # When & Then
             self.assertRaises(ClientError, self._plugin.create)
 
-    def test_no_policy_with_no_extra_deploy_accounts(self):
+    def test_no_policy_when_only_one_account(self):
         # Given
         self._release.deploy_account_ids = [
             self._account_id

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -366,6 +366,101 @@ class TestRelease(unittest.TestCase):
                 }, sort_keys=True)
             )
 
+    @given(fixed_dictionaries({
+        'component_name': text(
+            alphabet=IDENTIFIER_ALPHABET, min_size=8, max_size=16
+        ),
+        'accounts': lists(
+            elements=account(), min_size=2, max_size=4,
+            unique_by=lambda account: account['alias']
+        ),
+    }))
+    def test_lifecycle_policy_gets_created_when_missing(self, fixtures):
+        component_name = fixtures['component_name']
+        accounts = fixtures['accounts']
+
+        account_ids = [account['id'] for account in accounts]
+        assume(len(set(account_ids)) == len(account_ids))
+
+        self._release.component_name = component_name
+        account_scheme = AccountScheme.create({
+            'accounts': {
+                account['alias']: {
+                    'id': account['id'],
+                    'role': account['role']
+                }
+                for account in accounts
+            },
+            'release-account': accounts[0]['alias'],
+            'default-region': self._region,
+            'release-bucket': 'dummy',
+            'environments': {
+                'live': accounts[0]['alias'],
+            },
+        })
+        plugin = ReleasePlugin(self._release, account_scheme)
+        self._ecr_client.get_lifecycle_policy = Mock()
+        self._ecr_client.get_lifecycle_policy.side_effect = ClientError(
+            {'Error': {'Code': 'LifecyclePolicyNotFoundException'}},
+            None
+        )
+        self._ecr_client.put_lifecycle_policy = Mock()
+
+        with patch('cdflow_commands.plugins.ecs.check_call'):
+            plugin.create()
+
+            self._ecr_client.get_lifecycle_policy.assert_called_once_with(
+                registryId=accounts[0].get('id'),
+                repositoryName=component_name
+            )
+            self._ecr_client.put_lifecycle_policy.assert_called_once()
+
+    @given(fixed_dictionaries({
+        'component_name': text(
+            alphabet=IDENTIFIER_ALPHABET, min_size=8, max_size=16
+        ),
+        'accounts': lists(
+            elements=account(), min_size=2, max_size=4,
+            unique_by=lambda account: account['alias']
+        ),
+    }))
+    def test_lifecycle_policy_doesnt_get_created_when_exists(self, fixtures):
+        component_name = fixtures['component_name']
+        accounts = fixtures['accounts']
+
+        account_ids = [account['id'] for account in accounts]
+        assume(len(set(account_ids)) == len(account_ids))
+
+        self._release.component_name = component_name
+        account_scheme = AccountScheme.create({
+            'accounts': {
+                account['alias']: {
+                    'id': account['id'],
+                    'role': account['role']
+                }
+                for account in accounts
+            },
+            'release-account': accounts[0]['alias'],
+            'default-region': self._region,
+            'release-bucket': 'dummy',
+            'environments': {
+                'live': accounts[0]['alias'],
+            },
+        })
+        plugin = ReleasePlugin(self._release, account_scheme)
+        self._ecr_client.get_lifecycle_policy = Mock()
+        self._ecr_client.get_lifecycle_policy.return_value = "qwerty"
+        self._ecr_client.put_lifecycle_policy = Mock()
+
+        with patch('cdflow_commands.plugins.ecs.check_call'):
+            plugin.create()
+
+            self._ecr_client.get_lifecycle_policy.assert_called_once_with(
+                registryId=accounts[0].get('id'),
+                repositoryName=component_name
+            )
+            self._ecr_client.put_lifecycle_policy.assert_not_called()
+
     @patch('cdflow_commands.plugins.ecs.check_call')
     @patch('cdflow_commands.plugins.ecs.path')
     def test_runs_on_docker_build_script_if_one_is_present(


### PR DESCRIPTION
We'd like to utilise AWS ECR Lifecycle Policies to make sure we never exceed the maximum number of images within a single ECR repository (it happened for some projects).

The Lifecycle policy we're applying keeps the first 500 images (sorted by date, from the most recent) and expires 500+ images.
