### PR TITLE
Stop enforcing ECR lifcycle

### DIFF
--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -33,7 +33,7 @@ class ReleasePlugin:
         if self._release.version:
             self._ensure_ecr_repo_exists()
             self._ensure_ecr_policy_set()
-            #self._ensure_ecr_lifecycle_policy_set()
+            # self._ensure_ecr_lifecycle_policy_set()
             self._docker_login()
             self._docker_push(self._image_name)
             self._docker_tag_latest()

--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -33,7 +33,7 @@ class ReleasePlugin:
         if self._release.version:
             self._ensure_ecr_repo_exists()
             self._ensure_ecr_policy_set()
-            self._ensure_ecr_lifecycle_policy_set()
+            #self._ensure_ecr_lifecycle_policy_set()
             self._docker_login()
             self._docker_push(self._image_name)
             self._docker_tag_latest()

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -12,6 +12,7 @@ from cdflow_commands.release import Release
 from hypothesis import assume, given
 from hypothesis.strategies import fixed_dictionaries, text, lists
 from mock import MagicMock, Mock, patch
+import pytest
 
 from test.test_account import account
 
@@ -366,6 +367,7 @@ class TestRelease(unittest.TestCase):
                 }, sort_keys=True)
             )
 
+    @pytest.mark.skip('Stopped enforcing lifecycle while fixing a bug')
     @given(fixed_dictionaries({
         'component_name': text(
             alphabet=IDENTIFIER_ALPHABET, min_size=8, max_size=16


### PR DESCRIPTION
The method is not found on the ECR object for some reason.