### PR TITLE
Add tls provider and upgrade Terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV TERRAFORM_PROVIDER_NULL_VERSION=1.0.0
 ENV TERRAFORM_PROVIDER_TEMPLATE_VERSION=1.0.0
 ENV TERRAFORM_PROVIDER_ACME_VERSION=0.3.0
 ENV TERRAFORM_PROVIDER_EXTERNAL_VERSION=1.0.0
+ENV TERRAFORM_PROVIDER_TLS_VERSION=1.0.1
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/main >> /etc/apk/repositories
 RUN apk update
@@ -31,6 +32,8 @@ RUN cd /tmp && \
         unzip terraform-provider-acme_*_linux_amd64.zip -d /usr/bin && \
     curl -sSLO https://releases.hashicorp.com/terraform-provider-external/$TERRAFORM_PROVIDER_EXTERNAL_VERSION/terraform-provider-external_${TERRAFORM_PROVIDER_EXTERNAL_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-external_*_linux_amd64.zip -d /usr/bin && \
+    curl -sSLO https://releases.hashicorp.com/terraform-provider-tls/$TERRAFORM_PROVIDER_TLS_VERSION/terraform-provider-tls_${TERRAFORM_PROVIDER_TLS_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-tls*_linux_amd64.zip -d /usr/bin && \
     rm -rf /tmp/* && \
     rm -rf /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3-alpine3.6
 
-ENV TERRAFORM_VERSION=0.11.0
+ENV TERRAFORM_VERSION=0.11.1
 
-ENV TERRAFORM_PROVIDER_AWS_VERSION=1.5.0
-ENV TERRAFORM_PROVIDER_FASTLY_VERSION=0.1.2_le-support
+ENV TERRAFORM_PROVIDER_AWS_VERSION=1.6.0
+ENV TERRAFORM_PROVIDER_FASTLY_VERSION=0.1.3
 ENV TERRAFORM_PROVIDER_LOGENTRIES_VERSION=0.1.0_logset_datasource
 ENV TERRAFORM_PROVIDER_NULL_VERSION=1.0.0
 ENV TERRAFORM_PROVIDER_TEMPLATE_VERSION=1.0.0
@@ -20,7 +20,7 @@ RUN cd /tmp && \
         unzip terraform_*_linux_amd64.zip -d /usr/bin && \
     curl -sSLO https://releases.hashicorp.com/terraform-provider-aws/$TERRAFORM_PROVIDER_AWS_VERSION/terraform-provider-aws_${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-aws_*_linux_amd64.zip -d /usr/bin && \
-    wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-fastly_v${TERRAFORM_PROVIDER_FASTLY_VERSION}_linux_amd64.zip && \
+    curl -sSLO https://releases.hashicorp.com/terraform-provider-fastly/$TERRAFORM_PROVIDER_FASTLY_VERSION/terraform-provider-fastly_${TERRAFORM_PROVIDER_FASTLY_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-fastly_*_linux_amd64.zip -d /usr/bin && \
     wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-logentries_v${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-logentries_*_linux_amd64.zip -d /usr/bin && \


### PR DESCRIPTION
We use this provider in the openvpn code but the build fails at the moment because it's not included in the `cdflow-commands` image.

There is a patch release of Terraform available, plus our pull request to the Fastly provider has been merged. There is also a new version of the AWS provider.