### PR TITLE
Jenkins Slave Pool

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -4,7 +4,7 @@ cdflow
 Create and manage software services using continuous delivery.
 
 Usage:
-    cdflow release (--platform-config <platform_config>)... <version> [options]
+    cdflow release (--platform-config <platform_config>)... [--release-data=key:value]... <version> [options]
     cdflow deploy <environment> <version> [options]
     cdflow destroy <environment> [options]
 
@@ -23,7 +23,7 @@ from subprocess import check_output
 from boto3.session import Session
 
 from cdflow_commands.config import (
-    assume_role, get_component_name, load_manifest, build_account_scheme
+    assume_role, get_component_name, get_release_data, load_manifest, build_account_scheme
 )
 from cdflow_commands.constants import (
     INFRASTRUCTURE_DEFINITIONS_PATH, TERRAFORM_DESTROY_DEFINITION,
@@ -97,11 +97,11 @@ def run_release(release_account_session, account_scheme, manifest, args):
     commit = check_output(
         ['git', 'rev-parse', 'HEAD']
     ).decode('utf-8').strip()
-
     release = Release(
         boto_session=release_account_session,
         release_bucket=account_scheme.release_bucket,
         platform_config_paths=args['<platform_config>'],
+        release_data=args['--release-data'],
         version=args['<version>'],
         commit=commit,
         component_name=get_component_name(args['--component']),

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -23,7 +23,7 @@ from subprocess import check_output
 from boto3.session import Session
 
 from cdflow_commands.config import (
-    assume_role, get_component_name, get_release_data, load_manifest, build_account_scheme
+    assume_role, get_component_name, load_manifest, build_account_scheme
 )
 from cdflow_commands.constants import (
     INFRASTRUCTURE_DEFINITIONS_PATH, TERRAFORM_DESTROY_DEFINITION,

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -5,7 +5,7 @@ Create and manage software services using continuous delivery.
 
 Usage:
     cdflow release (--platform-config <platform_config>)...
-                   [--release-data=key:value]... <version> [options]
+                   [--release-data=key=value]... <version> [options]
     cdflow deploy <environment> <version> [options]
     cdflow destroy <environment> [options]
 

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -4,7 +4,8 @@ cdflow
 Create and manage software services using continuous delivery.
 
 Usage:
-    cdflow release (--platform-config <platform_config>)... [--release-data=key:value]... <version> [options]
+    cdflow release (--platform-config <platform_config>)...
+                   [--release-data=key:value]... <version> [options]
     cdflow deploy <environment> <version> [options]
     cdflow destroy <environment> [options]
 

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -102,6 +102,11 @@ def get_component_name(component_name):
         return component_name
     return _get_component_name_from_git_remote()
 
+def get_release_data(release_data):
+    if release_data:
+        return release_data
+    return []
+
 
 def _get_component_name_from_git_remote():
     try:

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -102,11 +102,6 @@ def get_component_name(component_name):
         return component_name
     return _get_component_name_from_git_remote()
 
-def get_release_data(release_data):
-    if release_data:
-        return release_data
-    return []
-
 
 def _get_component_name_from_git_remote():
     try:

--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -81,7 +81,8 @@ def _copy_platform_config(source_dir, dest_dir):
 class Release:
 
     def __init__(
-        self, boto_session, release_bucket, platform_config_paths, release_data, commit,
+        self, boto_session, release_bucket, platform_config_paths,
+        release_data, commit,
         version, component_name, team
     ):
         self.boto_session = boto_session
@@ -114,7 +115,9 @@ class Release:
 
             extra_data = plugin.create()
 
-            self._generate_release_metadata(base_dir, self.release_data, extra_data)
+            self._generate_release_metadata(base_dir,
+                                            self.release_data,
+                                            extra_data)
 
             release_archive = make_archive(
                 base_dir, 'zip', temp_dir,
@@ -131,7 +134,7 @@ class Release:
             'team': self._team,
         }
 
-        release_map={ key:value for key,value in (data_item.split(':',1) for data_item in release_data) }
+        release_map = dict(item.split(':', 1) for item in release_data)
 
         with open(path.join(base_dir, RELEASE_METADATA_FILE), 'w') as f:
             f.write(json.dumps({

--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -134,7 +134,7 @@ class Release:
             'team': self._team,
         }
 
-        release_map = dict(item.split(':', 1) for item in release_data)
+        release_map = dict(item.split('=', 1) for item in release_data)
 
         with open(path.join(base_dir, RELEASE_METADATA_FILE), 'w') as f:
             f.write(json.dumps({

--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -81,12 +81,13 @@ def _copy_platform_config(source_dir, dest_dir):
 class Release:
 
     def __init__(
-        self, boto_session, release_bucket, platform_config_paths, commit,
+        self, boto_session, release_bucket, platform_config_paths, release_data, commit,
         version, component_name, team
     ):
         self.boto_session = boto_session
         self._release_bucket = release_bucket
         self._platform_config_paths = platform_config_paths
+        self.release_data = release_data
         self._commit = commit
         self._team = team
         self.version = version
@@ -113,7 +114,7 @@ class Release:
 
             extra_data = plugin.create()
 
-            self._generate_release_metadata(base_dir, extra_data)
+            self._generate_release_metadata(base_dir, self.release_data, extra_data)
 
             release_archive = make_archive(
                 base_dir, 'zip', temp_dir,
@@ -122,7 +123,7 @@ class Release:
 
             self._upload_archive(release_archive)
 
-    def _generate_release_metadata(self, base_dir, extra_data):
+    def _generate_release_metadata(self, base_dir, release_data, extra_data):
         base_data = {
             'commit': self._commit,
             'version': self.version,
@@ -130,9 +131,11 @@ class Release:
             'team': self._team,
         }
 
+        release_map={ key:value for key,value in (data_item.split(':',1) for data_item in release_data) }
+
         with open(path.join(base_dir, RELEASE_METADATA_FILE), 'w') as f:
             f.write(json.dumps({
-                'release': dict(**base_data, **extra_data)
+                'release': dict(**base_data, **release_map, **extra_data)
             }))
 
     def _setup_base_dir(self, temp_dir):

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -23,7 +23,8 @@ class TestRelease(unittest.TestCase):
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_paths=[ANY], commit=ANY, version=version,
+            platform_config_paths=[ANY],
+            release_data=["1:1"], commit=ANY, version=version,
             component_name=ANY, team=ANY
         )
 
@@ -36,7 +37,8 @@ class TestRelease(unittest.TestCase):
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_paths=[ANY], commit=ANY, version=ANY,
+            platform_config_paths=[ANY],
+            release_data=["1:1"], commit=ANY, version=ANY,
             component_name=component_name, team=ANY
         )
 
@@ -69,6 +71,7 @@ class TestReleaseArchive(unittest.TestCase):
             boto_session=Mock(),
             release_bucket=ANY,
             platform_config_paths=[ANY],
+            release_data=["1:1"],
             commit='dummy',
             version='dummy-version',
             component_name='dummy-component',
@@ -113,10 +116,12 @@ class TestReleaseArchive(unittest.TestCase):
             'test-platform-config-path-a',
             'test-platform-config-path-b',
         ]
+        release_data = ["ami_id:ami-a12345", "foo:bar"]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_paths=platform_config_paths, commit='dummy',
+            platform_config_paths=platform_config_paths,
+            release_data=release_data, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
         )
@@ -194,10 +199,13 @@ class TestReleaseArchive(unittest.TestCase):
         release_plugin = Mock()
         release_plugin.create.return_value = {}
         platform_config_paths = ['test-platform-config-path']
+        release_data = ["ami_id:ami-a12345", "foo:bar"]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_paths=platform_config_paths, commit='dummy',
+            platform_config_paths=platform_config_paths,
+            release_data=release_data,
+            commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
         )
@@ -231,10 +239,13 @@ class TestReleaseArchive(unittest.TestCase):
         release_plugin = Mock()
         release_plugin.create.return_value = {}
         platform_config_paths = ['test-platform-config-path']
+        release_data = ["ami_id:ami-a12345", "foo:bar"]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_paths=platform_config_paths, commit='dummy',
+            platform_config_paths=platform_config_paths,
+            release_data=release_data,
+            commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
         )
@@ -266,10 +277,12 @@ class TestReleaseArchive(unittest.TestCase):
         release_plugin = Mock()
         release_plugin.create.return_value = {}
         platform_config_paths = 'test-platform-config-path'
+        release_data = ["ami_id:ami-a12345", "foo:bar"]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
-            platform_config_paths=platform_config_paths, commit='dummy',
+            platform_config_paths=platform_config_paths,
+            release_data=release_data, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
         )
@@ -302,6 +315,7 @@ class TestReleaseArchive(unittest.TestCase):
         team = fixtures['team']
         plugin_data = fixtures['plugin_data']
         temp_dir = fixtures['temp_dir']
+        release_data = ["1234:2345"]
 
         release_plugin = Mock()
         release_plugin.create.return_value = plugin_data
@@ -310,6 +324,7 @@ class TestReleaseArchive(unittest.TestCase):
             boto_session=Mock(),
             release_bucket=ANY,
             platform_config_paths='platform-config',
+            release_data=release_data,
             commit=commit,
             version=version,
             component_name=component_name,
@@ -341,6 +356,7 @@ class TestReleaseArchive(unittest.TestCase):
                 'team': team,
             }
 
+            release_map = dict(item.split(':', 1) for item in release_data)
             # When
             release.create(release_plugin)
 
@@ -352,7 +368,9 @@ class TestReleaseArchive(unittest.TestCase):
                 ), 'w'
             )
             mock_file.write.assert_called_once_with(json.dumps({
-                'release': dict(**base_release_metadata, **plugin_data)
+                'release': dict(**base_release_metadata,
+                                **release_map,
+                                **plugin_data)
             }))
 
     @patch('cdflow_commands.release._copy_platform_config')
@@ -377,6 +395,7 @@ class TestReleaseArchive(unittest.TestCase):
             boto_session=Mock(),
             release_bucket=ANY,
             platform_config_paths='test-platform-config-path',
+            release_data=["1234:5678"],
             commit=commit,
             version=version,
             component_name=component_name,
@@ -426,6 +445,7 @@ class TestReleaseArchive(unittest.TestCase):
             boto_session=mock_session,
             release_bucket=release_bucket,
             platform_config_paths='test-platform-config-path',
+            release_data=["1234:5678"],
             commit=commit,
             version=version,
             component_name=component_name,

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -24,7 +24,7 @@ class TestRelease(unittest.TestCase):
             boto_session=Mock(),
             release_bucket=ANY,
             platform_config_paths=[ANY],
-            release_data=["1:1"], commit=ANY, version=version,
+            release_data=["1=1"], commit=ANY, version=version,
             component_name=ANY, team=ANY
         )
 
@@ -38,7 +38,7 @@ class TestRelease(unittest.TestCase):
             boto_session=Mock(),
             release_bucket=ANY,
             platform_config_paths=[ANY],
-            release_data=["1:1"], commit=ANY, version=ANY,
+            release_data=["1=1"], commit=ANY, version=ANY,
             component_name=component_name, team=ANY
         )
 
@@ -71,7 +71,7 @@ class TestReleaseArchive(unittest.TestCase):
             boto_session=Mock(),
             release_bucket=ANY,
             platform_config_paths=[ANY],
-            release_data=["1:1"],
+            release_data=["1=1"],
             commit='dummy',
             version='dummy-version',
             component_name='dummy-component',
@@ -116,7 +116,7 @@ class TestReleaseArchive(unittest.TestCase):
             'test-platform-config-path-a',
             'test-platform-config-path-b',
         ]
-        release_data = ["ami_id:ami-a12345", "foo:bar"]
+        release_data = ["ami_id=ami-a12345", "foo=bar"]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
@@ -199,7 +199,7 @@ class TestReleaseArchive(unittest.TestCase):
         release_plugin = Mock()
         release_plugin.create.return_value = {}
         platform_config_paths = ['test-platform-config-path']
-        release_data = ["ami_id:ami-a12345", "foo:bar"]
+        release_data = ["ami_id=ami-a12345", "foo=bar"]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
@@ -239,7 +239,7 @@ class TestReleaseArchive(unittest.TestCase):
         release_plugin = Mock()
         release_plugin.create.return_value = {}
         platform_config_paths = ['test-platform-config-path']
-        release_data = ["ami_id:ami-a12345", "foo:bar"]
+        release_data = ["ami_id=ami-a12345", "foo=bar"]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
@@ -277,7 +277,7 @@ class TestReleaseArchive(unittest.TestCase):
         release_plugin = Mock()
         release_plugin.create.return_value = {}
         platform_config_paths = 'test-platform-config-path'
-        release_data = ["ami_id:ami-a12345", "foo:bar"]
+        release_data = ["ami_id=ami-a12345", "foo=bar"]
         release = Release(
             boto_session=Mock(),
             release_bucket=ANY,
@@ -315,7 +315,7 @@ class TestReleaseArchive(unittest.TestCase):
         team = fixtures['team']
         plugin_data = fixtures['plugin_data']
         temp_dir = fixtures['temp_dir']
-        release_data = ["1234:2345"]
+        release_data = ["1234=2345"]
 
         release_plugin = Mock()
         release_plugin.create.return_value = plugin_data
@@ -356,7 +356,7 @@ class TestReleaseArchive(unittest.TestCase):
                 'team': team,
             }
 
-            release_map = dict(item.split(':', 1) for item in release_data)
+            release_map = dict(item.split('=', 1) for item in release_data)
             # When
             release.create(release_plugin)
 
@@ -395,7 +395,7 @@ class TestReleaseArchive(unittest.TestCase):
             boto_session=Mock(),
             release_bucket=ANY,
             platform_config_paths='test-platform-config-path',
-            release_data=["1234:5678"],
+            release_data=["1234=5678"],
             commit=commit,
             version=version,
             component_name=component_name,
@@ -445,7 +445,7 @@ class TestReleaseArchive(unittest.TestCase):
             boto_session=mock_session,
             release_bucket=release_bucket,
             platform_config_paths='test-platform-config-path',
-            release_data=["1234:5678"],
+            release_data=["1234=5678"],
             commit=commit,
             version=version,
             component_name=component_name,


### PR DESCRIPTION
Add in new command line option '--release-data'
Can be used 0 to many times to send in extra data to the release
Will be stored in the release.json