### PR TITLE
Using lambda bucket name from account-scheme.json

### DIFF
--- a/cdflow_commands/account.py
+++ b/cdflow_commands/account.py
@@ -14,12 +14,13 @@ class AccountScheme:
     DEFAULT_ENV_KEY = '*'
 
     def __init__(
-        self, accounts, release_account, release_bucket,
+        self, accounts, release_account, release_bucket, lambda_bucket,
         default_region, environment_mapping, multiple_account_deploys
     ):
         self.accounts = accounts
         self.release_account = release_account
         self.release_bucket = release_bucket
+        self.lambda_bucket = lambda_bucket
         self.default_region = default_region
         self._environment_mapping = environment_mapping
         self.multiple_account_deploys = multiple_account_deploys
@@ -97,6 +98,7 @@ class AccountScheme:
             set(accounts.values()),
             accounts[raw_scheme['release-account']],
             raw_scheme['release-bucket'],
+            raw_scheme.get('lambda-bucket', ''),
             raw_scheme['default-region'],
             environment_mapping,
             multiple_account_deploys

--- a/cdflow_commands/plugins/aws_lambda.py
+++ b/cdflow_commands/plugins/aws_lambda.py
@@ -8,8 +8,6 @@ from cdflow_commands.state import S3BucketFactory
 
 class ReleasePlugin:
 
-    _BUCKET_NAME = 'cdflow-lambda-releases'
-
     def __init__(self, release, account_scheme):
         self._boto_session = release.boto_session
         self._component_name = release.component_name
@@ -32,7 +30,7 @@ class ReleasePlugin:
             self._boto_session, self._account_scheme.release_account.id
         )
         created_bucket_name = s3_bucket_factory.get_bucket_name(
-            self._BUCKET_NAME
+            self._account_scheme.lambda_bucket
         )
         self._upload_zip_to_bucket(
             created_bucket_name, zipped_folder.filename

--- a/cdflow_commands/state.py
+++ b/cdflow_commands/state.py
@@ -13,7 +13,7 @@ from cdflow_commands.logger import logger
 from cdflow_commands.process import check_call
 
 TFSTATE_NAME_PREFIX = 'cdflow-tfstate'
-LAMBDA_BUCKET_NAME = 'cdflow-lambda-releases'
+LAMBDA_BUCKET_PREFIX = 'cdflow-lambda-releases'
 TFSTATE_TAG_NAME = 'is-cdflow-tfstate-bucket'
 LAMBDA_TAG_NAME = 'is-cdflow-lambda-bucket'
 TAG_VALUE = 'true'
@@ -209,7 +209,7 @@ class S3BucketFactory:
 
         if bucket_name_prefix == TFSTATE_NAME_PREFIX:
             bucket_tag = TFSTATE_TAG_NAME
-        if bucket_name_prefix == LAMBDA_BUCKET_NAME:
+        if LAMBDA_BUCKET_PREFIX in bucket_name_prefix:
             bucket_tag = LAMBDA_TAG_NAME
 
         buckets = {
@@ -278,7 +278,7 @@ class S3BucketFactory:
                     attempt, bucket_name_prefix
                 )
             else:
-                bucket_name = LAMBDA_BUCKET_NAME
+                bucket_name = bucket_name_prefix
             if self._attempt_to_create_bucket(bucket_name):
                 logger.debug(
                     's3 bucket with name: {} created'.format(bucket_name)

--- a/test/plugins/test_lambda_release.py
+++ b/test/plugins/test_lambda_release.py
@@ -36,6 +36,7 @@ class TestLambdaReleasePlugin(unittest.TestCase):
             'release-account': 'dummy',
             'default-region': self._region,
             'release-bucket': 'dummy',
+            'lambda-bucket': 'dummy-lambda-bucket',
             'environments': {
                 'live': 'dummy',
             },
@@ -84,7 +85,7 @@ class TestLambdaReleasePlugin(unittest.TestCase):
         self._plugin.create()
         # Then
         s3_bucket_factory_mock.get_bucket_name.assert_called_once_with(
-            'cdflow-lambda-releases'
+            'dummy-lambda-bucket'
         )
 
     @patch('cdflow_commands.plugins.aws_lambda.os')

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -50,6 +50,7 @@ class TestAccountScheme(unittest.TestCase):
         'account': account(),
         'region': text(min_size=1),
         'release-bucket': text(),
+        'lambda-bucket': text()
     }))
     def test_create_account_scheme_from_json(self, fixtures):
         raw_scheme = {
@@ -60,6 +61,7 @@ class TestAccountScheme(unittest.TestCase):
                 }
             },
             'release-bucket': fixtures['release-bucket'],
+            'lambda-bucket': fixtures['lambda-bucket'],
             'release-account': fixtures['account']['alias'],
             'default-region': fixtures['region'],
             'environments': {},
@@ -72,6 +74,7 @@ class TestAccountScheme(unittest.TestCase):
         assert account_scheme.default_region == fixtures['region']
         assert account_scheme.accounts == {account_scheme.release_account}
         assert account_scheme.release_bucket == fixtures['release-bucket']
+        assert account_scheme.lambda_bucket == fixtures['lambda-bucket']
 
     @given(accounts())
     def test_deploy_account_ids(self, accounts):


### PR DESCRIPTION
We were trying to create buckets with the same name that we've already
created. This should solve that for each account. Now we will pull it
from the account-scheme.json. To ensure backwards compatability we set
the lambda bucket to empty if not in the account-scheme. This is to
deploy a lambda into the svcs account.

JIRA: PLAT-1325