### PR TITLE
Removing create bucket logic from lambda release

### DIFF
--- a/cdflow_commands/plugins/aws_lambda.py
+++ b/cdflow_commands/plugins/aws_lambda.py
@@ -3,7 +3,6 @@ from zipfile import ZipFile
 from contextlib import contextmanager
 
 from cdflow_commands.logger import logger
-from cdflow_commands.state import S3BucketFactory
 
 
 class ReleasePlugin:
@@ -26,19 +25,13 @@ class ReleasePlugin:
 
     def create(self):
         zipped_folder = self._zip_up_component()
-        s3_bucket_factory = S3BucketFactory(
-            self._boto_session, self._account_scheme.release_account.id
-        )
-        created_bucket_name = s3_bucket_factory.get_bucket_name(
-            self._account_scheme.lambda_bucket
-        )
         self._upload_zip_to_bucket(
-            created_bucket_name, zipped_folder.filename
+            self._account_scheme.lambda_bucket, zipped_folder.filename
         )
         self._remove_zipped_folder(zipped_folder.filename)
 
         return {
-            's3_bucket': created_bucket_name,
+            's3_bucket': self._account_scheme.lambda_bucket,
             's3_key': self._lambda_s3_key,
         }
 

--- a/cdflow_commands/state.py
+++ b/cdflow_commands/state.py
@@ -13,9 +13,7 @@ from cdflow_commands.logger import logger
 from cdflow_commands.process import check_call
 
 TFSTATE_NAME_PREFIX = 'cdflow-tfstate'
-LAMBDA_BUCKET_PREFIX = 'cdflow-lambda-releases'
 TFSTATE_TAG_NAME = 'is-cdflow-tfstate-bucket'
-LAMBDA_TAG_NAME = 'is-cdflow-lambda-bucket'
 TAG_VALUE = 'true'
 MAX_CREATION_ATTEMPTS = 10
 
@@ -207,10 +205,7 @@ class S3BucketFactory:
 
     def get_bucket_name(self, bucket_name_prefix=TFSTATE_NAME_PREFIX):
 
-        if bucket_name_prefix == TFSTATE_NAME_PREFIX:
-            bucket_tag = TFSTATE_TAG_NAME
-        if LAMBDA_BUCKET_PREFIX in bucket_name_prefix:
-            bucket_tag = LAMBDA_TAG_NAME
+        bucket_tag = TFSTATE_TAG_NAME
 
         buckets = {
             bucket['Name']

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -7,7 +7,6 @@ from mock import Mock, MagicMock, patch, mock_open
 import yaml
 
 from cdflow_commands import cli
-from cdflow_commands.state import S3BucketFactory
 
 
 class TestReleaseCLI(unittest.TestCase):
@@ -16,10 +15,6 @@ class TestReleaseCLI(unittest.TestCase):
     @patch('cdflow_commands.cli.check_output')
     @patch('cdflow_commands.plugins.aws_lambda.ZipFile')
     @patch('cdflow_commands.plugins.aws_lambda.os')
-    @patch(
-        'cdflow_commands.plugins.aws_lambda.S3BucketFactory',
-        autospec=S3BucketFactory
-    )
     @patch('cdflow_commands.release.os')
     @patch('cdflow_commands.release.copytree')
     @patch('cdflow_commands.release.check_call')
@@ -34,7 +29,7 @@ class TestReleaseCLI(unittest.TestCase):
     def test_release_package_is_created(
         self, check_output, mock_open_config, Session_from_config,
         Session_from_cli, rmtree, mock_os, mock_open_release, make_archive,
-        check_call, copytree, mock_os_release, S3BucketFactory, mock_os_lambda,
+        check_call, copytree, mock_os_release, mock_os_lambda,
         ZipFile, check_output_cli, _
     ):
         # Given
@@ -65,6 +60,7 @@ class TestReleaseCLI(unittest.TestCase):
             'release-account': 'foodev',
             'release-bucket': 'releases',
             'default-region': 'us-north-4',
+            'lambda-bucket': 'dummy-lambda-bucket',
             'environments': {
                 'live': 'foodev',
             },
@@ -108,9 +104,6 @@ class TestReleaseCLI(unittest.TestCase):
         }
         mock_root_session.client.return_value = mock_sts
 
-        S3BucketFactory.return_value.get_bucket_name.return_value \
-            = 'lambda-bucket'
-
         component_name = 'dummy-component'
         version = '6.1.7'
 
@@ -129,7 +122,7 @@ class TestReleaseCLI(unittest.TestCase):
         # Then
         mock_s3_client.upload_file.assert_called_once_with(
             ZipFile.return_value.__enter__.return_value.filename,
-            'lambda-bucket',
+            'dummy-lambda-bucket',
             'dummy-component/dummy-component-6.1.7.zip'
         )
 


### PR DESCRIPTION
To be more in line with the release bucket for services we're moving the
logic of creating the bucket into the terraform inside
account-resources.

JIRA: PLAT-1325