### PR TITLE
Support multi-region lambdas

### DIFF
--- a/cdflow_commands/account.py
+++ b/cdflow_commands/account.py
@@ -29,7 +29,7 @@ class AccountScheme:
 
     def __init__(
         self, raw_scheme, accounts, release_account, release_bucket,
-        lambda_bucket, default_region, environment_mapping,
+        lambda_bucket, lambda_buckets, default_region, environment_mapping,
         classic_metadata_handling, backend_s3_bucket, backend_s3_dynamodb_table
     ):
         self.raw_scheme = raw_scheme
@@ -37,6 +37,7 @@ class AccountScheme:
         self.release_account = release_account
         self.release_bucket = release_bucket
         self.lambda_bucket = lambda_bucket
+        self.lambda_buckets = lambda_buckets
         self.default_region = default_region
         self._environment_mapping = environment_mapping
         self.classic_metadata_handling = classic_metadata_handling
@@ -44,7 +45,7 @@ class AccountScheme:
             raise Exception('terraform-backend-s3-bucket is required')
         self.backend_s3_bucket = backend_s3_bucket
         if not classic_metadata_handling and backend_s3_dynamodb_table is None:
-            raise Exception('terraform-backend-s3-dynamodb_table is required')
+            raise Exception('terraform-backend-s3-dynamodb-table is required')
         self.backend_s3_dynamodb_table = backend_s3_dynamodb_table
 
     @classmethod
@@ -89,6 +90,7 @@ class AccountScheme:
             accounts[scheme['release-account']],
             scheme['release-bucket'],
             scheme.get('lambda-bucket', ''),
+            scheme.get('lambda-buckets', {}),
             scheme['default-region'],
             environment_mapping,
             scheme.get('classic-metadata-handling', False),

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -105,6 +105,7 @@ def run_release(release_account_session, account_scheme, manifest, args):
         component_name=get_component_name(args['--component']),
         team=manifest.team,
         account_scheme=account_scheme,
+        multi_region=manifest.multi_region,
     )
 
     if manifest.type == 'docker':

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -37,6 +37,7 @@ Manifest = namedtuple('Manifest', [
         'team',
         'type',
         'tfstate_filename',
+        'multi_region',
     ]
 )
 
@@ -49,6 +50,7 @@ def load_manifest():
             manifest_data['team'],
             manifest_data['type'],
             manifest_data.get('tfstate-filename', 'terraform.tfstate'),
+            manifest_data.get('multi-region', False),
         )
 
 

--- a/cdflow_commands/release.py
+++ b/cdflow_commands/release.py
@@ -99,7 +99,8 @@ class Release:
 
     def __init__(
         self, boto_session, release_bucket, platform_config_paths,
-        release_data, commit, version, component_name, team, account_scheme
+        release_data, commit, version, component_name, team, account_scheme,
+        multi_region
     ):
         self.boto_session = boto_session
         self._release_bucket = release_bucket
@@ -110,6 +111,7 @@ class Release:
         self.version = version
         self.component_name = component_name
         self.account_scheme = account_scheme
+        self.multi_region = multi_region
 
     def create(self, plugin):
         with TemporaryDirectory() as temp_dir:

--- a/test/plugins/test_lambda_release.py
+++ b/test/plugins/test_lambda_release.py
@@ -14,6 +14,7 @@ class TestLambdaReleasePlugin(unittest.TestCase):
         self._ecr_client = Mock()
         boto_session.client.return_value = self._ecr_client
         self._release = MagicMock(spec=Release)
+        self._release.multi_region = False
 
         self._release.boto_session = boto_session
 
@@ -25,7 +26,7 @@ class TestLambdaReleasePlugin(unittest.TestCase):
 
         self._region = 'dummy-region'
         self._account_id = 'dummy-account-id'
-        account_scheme = AccountScheme.create({
+        self._account_scheme = AccountScheme.create({
             'accounts': {
                 'dummy': {
                     'id': self._account_id,
@@ -36,6 +37,10 @@ class TestLambdaReleasePlugin(unittest.TestCase):
             'default-region': self._region,
             'release-bucket': 'dummy',
             'lambda-bucket': 'dummy-lambda-bucket',
+            'lambda-buckets': {
+                'test-region1': 'dummy-lambda-bucket',
+                'test-region2': 'dummy-lambda-bucket2',
+            },
             'environments': {
                 'live': 'dummy',
             },
@@ -43,7 +48,7 @@ class TestLambdaReleasePlugin(unittest.TestCase):
             'terraform-backend-s3-dynamodb-table': 'tflocks-table'
         }, 'a-team')
 
-        self._plugin = ReleasePlugin(self._release, account_scheme)
+        self._plugin = ReleasePlugin(self._release, self._account_scheme)
 
     @patch('cdflow_commands.plugins.aws_lambda.os')
     @patch('cdflow_commands.plugins.aws_lambda.ZipFile')
@@ -79,6 +84,54 @@ class TestLambdaReleasePlugin(unittest.TestCase):
         boto_s3_client.upload_file.assert_called_once_with(
             zip_file().__enter__().filename,
             'dummy-lambda-bucket',
+            '{}/{}-{}.zip'.format(
+                self._component_name, self._component_name, self._version
+            )
+        )
+
+    @patch('cdflow_commands.plugins.aws_lambda.os')
+    @patch('cdflow_commands.plugins.aws_lambda.ZipFile')
+    def test_release_pushes_to_multiple_s3_regions(
+        self, zip_file, mock_os
+    ):
+        # Given
+        boto_s3_client_region1 = Mock()
+        boto_s3_client_region2 = Mock()
+        self._release.boto_session.client.side_effect = \
+            lambda service, region_name: boto_s3_client_region1 \
+            if region_name == 'test-region1' else boto_s3_client_region2
+        self._release.multi_region = True
+
+        # When
+        plugin_data = ReleasePlugin(
+            self._release, self._account_scheme
+        ).create()
+
+        # Then
+        self.assertEqual(plugin_data, {
+            's3_bucket.test-region1': 'dummy-lambda-bucket',
+            's3_bucket.test-region2': 'dummy-lambda-bucket2',
+            's3_bucket_regions_csv': 'test-region1,test-region2',
+            's3_key': '{}/{}-{}.zip'.format(
+                self._component_name, self._component_name, self._version
+            ),
+        })
+        self._release.boto_session.client.assert_any_call(
+            's3', region_name='test-region1'
+        )
+        self._release.boto_session.client.assert_any_call(
+            's3', region_name='test-region2'
+        )
+        boto_s3_client_region1.upload_file.assert_any_call(
+            zip_file().__enter__().filename,
+            'dummy-lambda-bucket',
+            '{}/{}-{}.zip'.format(
+                self._component_name, self._component_name, self._version
+            )
+        )
+        boto_s3_client_region2.upload_file.assert_any_call(
+            zip_file().__enter__().filename,
+            'dummy-lambda-bucket2',
             '{}/{}-{}.zip'.format(
                 self._component_name, self._component_name, self._version
             )

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -247,3 +247,20 @@ class TestAccountScheme(unittest.TestCase):
             '{team}-backend-bucket-{team}'.format(team=team)
         assert account_scheme.backend_s3_dynamodb_table == \
             '{team}-backend-dynamo-{team}'.format(team=team)
+
+    def test_multi_region_lambdas(self):
+        raw_scheme = {
+            'accounts': {'release': {'id': '1234567890', 'role': 'test-role'}},
+            'environments': {},
+            'release-account': 'release',
+            'release-bucket': 'release-bucket',
+            'default-region': 'test-region-1',
+            'terraform-backend-s3-bucket': 'backend-bucket',
+            'terraform-backend-s3-dynamodb-table': 'backend-table',
+            'lambda-buckets': {
+                'test-region-1': 'test-bucket-1',
+                'test-region-2': 'test-bucket-2'
+            }
+        }
+        account_scheme = AccountScheme.create(raw_scheme, 'test-team')
+        assert account_scheme.lambda_buckets == raw_scheme['lambda-buckets']

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -79,6 +79,7 @@ class TestLoadManifest(unittest.TestCase):
         assert manifest.team == fixtures['team']
         assert manifest.type == fixtures['type']
         assert manifest.tfstate_filename == 'terraform.tfstate'
+        assert not manifest.multi_region
 
     def test_tfstate_filename(self):
         # Given
@@ -100,6 +101,27 @@ class TestLoadManifest(unittest.TestCase):
 
         # Then
         assert manifest.tfstate_filename == 'test-tfstate-filename'
+
+    def test_multi_region(self):
+        # Given
+        mock_file = MagicMock(spec=TextIOWrapper)
+        mock_file.read.return_value = yaml.dump({
+            'account-scheme-url': 'dummy',
+            'team': 'dummy',
+            'type': 'dummy',
+            'multi-region': True
+        })
+
+        with patch(
+            'cdflow_commands.config.open', new_callable=mock_open, create=True
+        ) as open_:
+            open_.return_value.__enter__.return_value = mock_file
+
+            # When
+            manifest = config.load_manifest()
+
+        # Then
+        assert manifest.multi_region
 
 
 class TestAssumeRole(unittest.TestCase):

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -35,7 +35,8 @@ class TestRelease(unittest.TestCase):
             platform_config_paths=[ANY],
             release_data=["1=1"], commit=ANY, version=version,
             component_name=ANY, team=ANY,
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
 
         # When/Then
@@ -52,7 +53,8 @@ class TestRelease(unittest.TestCase):
             platform_config_paths=[ANY],
             release_data=["1=1"], commit=ANY, version=ANY,
             component_name=component_name, team=ANY,
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
 
         # When/Then
@@ -91,7 +93,8 @@ class TestReleaseArchive(unittest.TestCase):
             version='dummy-version',
             component_name='dummy-component',
             team='dummy-team',
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
         temp_dir = 'test-tmp-dir'
         TemporaryDirectory.return_value.__enter__.return_value = temp_dir
@@ -142,7 +145,8 @@ class TestReleaseArchive(unittest.TestCase):
             release_data=release_data, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
         temp_dir = 'test-temp-dir'
         TemporaryDirectory.return_value.__enter__.return_value = temp_dir
@@ -227,7 +231,8 @@ class TestReleaseArchive(unittest.TestCase):
             release_data=release_data, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
         temp_dir = 'test-temp-dir'
         TemporaryDirectory.return_value.__enter__.return_value = temp_dir
@@ -283,7 +288,8 @@ class TestReleaseArchive(unittest.TestCase):
             commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
         temp_dir = 'test-temp-dir'
         TemporaryDirectory.return_value.__enter__.return_value = temp_dir
@@ -326,7 +332,8 @@ class TestReleaseArchive(unittest.TestCase):
             commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
         temp_dir = 'test-temp-dir'
         TemporaryDirectory.return_value.__enter__.return_value = temp_dir
@@ -366,7 +373,8 @@ class TestReleaseArchive(unittest.TestCase):
             release_data=release_data, commit='dummy',
             version='dummy-version', component_name='dummy-component',
             team='dummy-team',
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
         temp_dir = 'test-temp-dir'
         TemporaryDirectory.return_value.__enter__.return_value = temp_dir
@@ -413,7 +421,8 @@ class TestReleaseArchive(unittest.TestCase):
             version=version,
             component_name=component_name,
             team=team,
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
 
         with ExitStack() as stack:
@@ -498,7 +507,8 @@ class TestReleaseArchive(unittest.TestCase):
             version=version,
             component_name=component_name,
             team='dummy-team',
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
         temp_dir = 'test-temp-dir'
         TemporaryDirectory.return_value.__enter__.return_value = temp_dir
@@ -551,7 +561,8 @@ class TestReleaseArchive(unittest.TestCase):
             version=version,
             component_name=component_name,
             team='dummy-team',
-            account_scheme=account_scheme
+            account_scheme=account_scheme,
+            multi_region=False,
         )
         temp_dir = 'test-temp-dir'
         TemporaryDirectory.return_value.__enter__.return_value = temp_dir


### PR DESCRIPTION
In order to provision lambdas in multiple regions, the release zip needs
to uploaded to a bucket in each region. This change adds a
`multi-region` flag to the `cdflow.yml` manifest that causes the lambda
plugin to upload the zip to a set of buckets configured in the account
scheme. It then provides details of these buckets in the release
metadata passed to terraform.