### PR TITLE
Stop ignoring role

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -79,7 +79,7 @@ def _run(argv):
     root_session = Session(region_name=account_scheme.default_region)
     release_account_session = assume_role(
         root_session, account_scheme.release_account.id,
-        account_scheme.default_region,
+        account_scheme.release_account.role, account_scheme.default_region,
     )
 
     if args['release']:
@@ -154,11 +154,11 @@ def run_non_release_command(
 def assume_infrastructure_account_role(
     account_scheme, environment, root_session
 ):
-    account_id = account_scheme.account_for_environment(environment).id
-    logger.debug('Assuming role in {}'.format(account_id))
+    account = account_scheme.account_for_environment(environment)
+    logger.debug(f'Assuming role {account.role} in {account.id}')
 
     return assume_role(
-        root_session, account_id, account_scheme.default_region,
+        root_session, account.id, account.role, account_scheme.default_region,
     )
 
 

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -54,16 +54,16 @@ def load_manifest():
         )
 
 
-def assume_role(root_session, acccount_id, region=None):
+def assume_role(root_session, account_id, role_name, region=None):
     sts = root_session.client('sts')
     session_name = get_role_session_name(sts)
     logger.debug(
         "Assuming role arn:aws:iam::{}:role/admin with session {}".format(
-            acccount_id, session_name
+            account_id, session_name
         )
     )
     response = sts.assume_role(
-        RoleArn='arn:aws:iam::{}:role/admin'.format(acccount_id),
+        RoleArn=f'arn:aws:iam::{account_id}:role/{role_name}',
         RoleSessionName=session_name,
     )
     return Session(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -146,6 +146,7 @@ class TestRoles(unittest.TestCase):
         assume_role.return_value = release_account_session
         account_scheme = Mock()
         account_scheme.release_account.id = '1234567890'
+        account_scheme.release_account.role = 'test-role'
         account_scheme.default_region = 'eu-west-12'
         build_account_scheme_s3.return_value = account_scheme
 
@@ -156,7 +157,7 @@ class TestRoles(unittest.TestCase):
 
         # Then
         assume_role.assert_called_once_with(
-            root_session, '1234567890', 'eu-west-12'
+            root_session, '1234567890', 'test-role', 'eu-west-12'
         )
         run_release.assert_called_once_with(
             release_account_session, account_scheme, ANY,
@@ -183,6 +184,7 @@ class TestRoles(unittest.TestCase):
         account_scheme.classic_metadata_handling = False
         infrastructure_account = Mock()
         infrastructure_account.id = '0987654321'
+        infrastructure_account.role = 'test-role'
         account_scheme.account_for_environment.return_value = \
             infrastructure_account
         build_account_scheme_file.return_value = account_scheme
@@ -199,7 +201,7 @@ class TestRoles(unittest.TestCase):
         # Then
         account_scheme.account_for_environment.assert_called_once_with('ci')
         assume_role.assert_called_once_with(
-            root_session, '0987654321', 'eu-west-12'
+            root_session, '0987654321', 'test-role', 'eu-west-12'
         )
         run_deploy.assert_called_once_with(
             ANY, account_scheme, release_account_session,
@@ -226,6 +228,7 @@ class TestRoles(unittest.TestCase):
         account_scheme.classic_metadata_handling = True
         infrastructure_account = Mock()
         infrastructure_account.id = '0987654321'
+        infrastructure_account.role = 'test-role'
         account_scheme.account_for_environment.return_value = \
             infrastructure_account
         build_account_scheme_file.return_value = account_scheme
@@ -242,7 +245,7 @@ class TestRoles(unittest.TestCase):
         # Then
         account_scheme.account_for_environment.assert_called_once_with('ci')
         assume_role.assert_called_once_with(
-            root_session, '0987654321', 'eu-west-12'
+            root_session, '0987654321', 'test-role', 'eu-west-12'
         )
         run_deploy.assert_called_once_with(
             ANY, account_scheme, infrastructure_account_session,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -154,13 +154,14 @@ class TestAssumeRole(unittest.TestCase):
         mock_root_session.client.return_value = mock_sts
 
         account_id = 123456789
-        session = config.assume_role(mock_root_session, account_id)
+        role_name = 'test-role-name'
+        session = config.assume_role(mock_root_session, account_id, role_name)
 
         assert session is mock_session
 
         mock_root_session.client.assert_called_once_with('sts')
         mock_sts.assume_role.assert_called_once_with(
-            RoleArn='arn:aws:iam::{}:role/admin'.format(account_id),
+            RoleArn='arn:aws:iam::{}:role/{}'.format(account_id, role_name),
             RoleSessionName=user_id,
         )
         MockSession.assert_called_once_with(
@@ -198,14 +199,15 @@ class TestAssumeRole(unittest.TestCase):
         mock_root_session.client.return_value = mock_sts
 
         account_id = 123456789
+        role_name = 'test-role-name'
         session = config.assume_role(
-            mock_root_session, account_id, region='us-west-4',
+            mock_root_session, account_id, role_name, region='us-west-4',
         )
         assert session is mock_session
 
         mock_root_session.client.assert_called_once_with('sts')
         mock_sts.assume_role.assert_called_once_with(
-            RoleArn='arn:aws:iam::{}:role/admin'.format(account_id),
+            RoleArn='arn:aws:iam::{}:role/{}'.format(account_id, role_name),
             RoleSessionName=user_id,
         )
         MockSession.assert_called_once_with(

--- a/test/test_integration_cli.py
+++ b/test/test_integration_cli.py
@@ -57,7 +57,7 @@ class TestDeployCLI(unittest.TestCase):
             'accounts': {
                 'foodev': {
                     'id': '123456789',
-                    'role': 'admon',
+                    'role': 'admin',
                 }
             },
             'release-account': 'foodev',
@@ -315,7 +315,7 @@ class TestDestroyCLI(unittest.TestCase):
             'accounts': {
                 'foodev': {
                     'id': '123456789',
-                    'role': 'admon',
+                    'role': 'admin',
                 }
             },
             'release-account': 'foodev',
@@ -547,7 +547,7 @@ class TestDestroyCLIClassicMetadataHandling(unittest.TestCase):
             'accounts': {
                 'foodev': {
                     'id': '123456789',
-                    'role': 'admon',
+                    'role': 'admin',
                 }
             },
             'release-account': 'foodev',

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -48,7 +48,7 @@ class TestReleaseCLI(unittest.TestCase):
             'accounts': {
                 'foodev': {
                     'id': '123456789',
-                    'role': 'admon',
+                    'role': 'admin',
                 }
             },
             'release-account': 'foodev',
@@ -181,7 +181,7 @@ class TestReleaseCLI(unittest.TestCase):
             'accounts': {
                 'foodev': {
                     'id': '123456789',
-                    'role': 'admon',
+                    'role': 'admin',
                 }
             },
             'release-account': 'foodev',

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -50,7 +50,7 @@ class TestReleaseCLI(unittest.TestCase):
             'accounts': {
                 'foodev': {
                     'id': '123456789',
-                    'role': 'admon',
+                    'role': 'admin',
                 }
             },
             'release-account': 'foodev',

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -54,7 +54,7 @@ class TestReleaseCLI(unittest.TestCase):
             'accounts': {
                 'foodev': {
                     'id': '123456789',
-                    'role': 'admon',
+                    'role': 'admin',
                 }
             },
             'release-account': 'foodev',


### PR DESCRIPTION
We have always had the role for each account configured in the account
scheme, but previously we ignored it and always assumed "admin". With
the release account we are using team specific roles, so this doesn't
work.