### PR TITLE
Deploy account for secrets in new account schemes

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -206,7 +206,7 @@ def run_deploy(
     secrets = {
         'secrets': get_secrets(
             environment, manifest.team,
-            component_name, metadata_account_session
+            component_name, infrastructure_account_session
         )
     }
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -285,3 +285,28 @@ class TestAccountSchemeHandling(unittest.TestCase):
         run_deploy.assert_called_once_with(
             ANY, release_account_scheme, ANY, ANY, ANY, ANY, ANY, ANY
         )
+
+
+class TestSecretsFromInfraAccount(unittest.TestCase):
+
+    @patch('cdflow_commands.cli.Deploy')
+    @patch('cdflow_commands.cli.initialise_terraform')
+    @patch('cdflow_commands.cli.get_secrets')
+    def test_secrets_in_deploy_account(self, get_secrets, _, _1):
+        # Given
+        deploy_session = Mock()
+        env = 'test-env'
+        manifest = Mock()
+        manifest.team = 'test-team'
+        component_name = 'test-component'
+        args = {'--plan-only': False}
+
+        # When
+        cli.run_deploy(
+            ANY, ANY, ANY, deploy_session, manifest, args, env, component_name
+        )
+
+        # Then
+        get_secrets.assert_called_once_with(
+            env, manifest.team, component_name, deploy_session
+        )


### PR DESCRIPTION
We were going to put this in the release account, but since have decided
to deprecate credstash in favour of secrets manager in the deploy
account. This behaviour involves the minimum of work before we are able
to remove this code (in particular no need to migrate credstash secrets
when moving components to the new account schemes.