### PR TITLE
Remove the deletion of the state key on destroy

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -239,12 +239,6 @@ def run_destroy(
 
     destroy.run(plan_only)
 
-    if not plan_only:
-        logger.info(
-            f'Removing state for {component_name} in {environment}'
-        )
-        state.delete()
-
 
 def conditionally_set_debug(verbose):
     if verbose:

--- a/cdflow_commands/state.py
+++ b/cdflow_commands/state.py
@@ -113,10 +113,6 @@ class TerraformStateClassic:
             cwd=self.base_directory,
         )
 
-    def delete(self):
-        s3_client = self.boto_session.client('s3')
-        s3_client.delete_object(Bucket=self.bucket, Key=self.state_file_key)
-
 
 class TerraformState:
 
@@ -246,10 +242,6 @@ class TerraformState:
                 f'Creating new workspace {self.environment_name}'
             )
             self.terraform_new_workspace()
-
-    def delete(self):
-        s3_client = self.boto_session.client('s3')
-        s3_client.delete_object(Bucket=self.bucket, Key=self.state_file_key)
 
 
 def terraform_state(

--- a/test/test_integration_cli.py
+++ b/test/test_integration_cli.py
@@ -419,7 +419,6 @@ class TestDestroyCLI(unittest.TestCase):
             TemporaryDirectory = self.setup_mocks(*args)
 
         environment = 'live'
-        state_file_key = join(component_name, environment, 'terraform.tfstate')
 
         workdir = '{}/{}-{}'.format(
             TemporaryDirectory.return_value.__enter__.return_value,
@@ -462,9 +461,7 @@ class TestDestroyCLI(unittest.TestCase):
             cwd=workdir,
         )
 
-        remove_state_mock_s3.delete_object.assert_called_once_with(
-            Bucket='tfstate-bucket', Key=state_file_key
-        )
+        remove_state_mock_s3.delete_object.assert_not_called()
 
     def test_plan_only_does_not_destroy_or_remove_state(self, *args):
         check_call_state, mock_assumed_session, time, aws_access_key_id, \
@@ -713,9 +710,7 @@ class TestDestroyCLIClassicMetadataHandling(unittest.TestCase):
             cwd=workdir,
         )
 
-        remove_state_mock_s3.delete_object.assert_called_once_with(
-            Bucket='tfstate', Key=state_file_key
-        )
+        remove_state_mock_s3.delete_object.assert_not_called()
 
     def test_plan_only_does_not_destroy_or_remove_state(self, *args):
         check_call_state, mock_assumed_session, time, aws_access_key_id, \


### PR DESCRIPTION
Removing the state causes a problem with the hash of the state in DynamoDB, which we don't remove. As we don't own this we shouldn't remove it.