### PR TITLE
Remove the manually installed acme provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM python:3.7.1-alpine3.8 AS base
 
 ENV TERRAFORM_VERSION=0.11.10
 
-ENV TERRAFORM_PROVIDER_ACME_VERSION=0.6.0
-
 ENV TERRAFORM_PLUGIN_DIR=/root/.terraform.d/plugins/
 
 ENV K8SVERSION=v1.8.11
@@ -25,8 +23,6 @@ RUN cd /tmp && \
 RUN mkdir -p "${TERRAFORM_PLUGIN_DIR}" && cd /tmp && \
     curl -sSLO "https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
         unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -d /usr/bin/ && \
-    wget -q "https://github.com/paybyphone/terraform-provider-acme/releases/download/v${TERRAFORM_PROVIDER_ACME_VERSION}/terraform-provider-acme_v${TERRAFORM_PROVIDER_ACME_VERSION}_linux_amd64.zip" && \
-        unzip "terraform-provider-acme_v${TERRAFORM_PROVIDER_ACME_VERSION}_linux_amd64.zip" -d "${TERRAFORM_PLUGIN_DIR}" && \
     rm -rf /tmp/* && \
     rm -rf /var/tmp/*
 


### PR DESCRIPTION
This is now in version 1.0 and is maintained as an official provider, therefore it is downloaded by Terraform when it's needed.