### PR TITLE
Update the paths in S3 for Lambdas and releases

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -131,15 +131,15 @@ def run_non_release_command(
 
     if args['destroy']:
         version = find_latest_release_version(
-            release_account_session, account_scheme.release_bucket,
+            release_account_session, account_scheme, manifest.team,
             component_name,
         )
     else:
         version = args['<version>']
 
     with fetch_release(
-        release_account_session, account_scheme.release_bucket,
-        component_name, version,
+        release_account_session, account_scheme, manifest.team, component_name,
+        version,
     ) as path_to_release:
         logger.debug('Unpacked release: {}'.format(path_to_release))
         path_to_release = os.path.join(

--- a/test/test_integration_cli.py
+++ b/test/test_integration_cli.py
@@ -306,10 +306,11 @@ class TestDestroyCLI(unittest.TestCase):
         Session_from_cli, rmtree, time, check_call_destroy, TemporaryDirectory,
         ZipFile, mock_os_release,
     ):
+        team_name = 'your-team'
         mock_metadata_file = MagicMock(spec=TextIOWrapper)
         metadata = {
             'account-scheme-url': 's3://bucket/key',
-            'team': 'your-team',
+            'team': team_name,
             'type': 'docker',
         }
         mock_metadata_file.read.return_value = yaml.dump(metadata)
@@ -390,7 +391,9 @@ class TestDestroyCLI(unittest.TestCase):
         mock_s3_resource = Mock()
         mock_release_bucket = Mock()
         mock_s3_objectsummary = Mock()
-        mock_s3_objectsummary.key = f'{component_name}/{component_name}-1.zip'
+        mock_s3_objectsummary.key = (
+            f'{team_name}/{component_name}/{component_name}-1.zip'
+        )
         mock_release_bucket.objects.filter.return_value = [
             mock_s3_objectsummary
         ]
@@ -409,14 +412,14 @@ class TestDestroyCLI(unittest.TestCase):
         return (
             check_call_state, mock_assumed_session, time, aws_access_key_id,
             aws_secret_access_key, aws_session_token, component_name,
-            check_call_destroy, mock_s3, TemporaryDirectory,
+            check_call_destroy, mock_s3, TemporaryDirectory, team_name,
         )
 
     def test_uses_terraform_to_destroy(self, *args):
         check_call_state, mock_assumed_session, time, aws_access_key_id, \
             aws_secret_access_key, aws_session_token, component_name, \
             check_call_destroy, remove_state_mock_s3, \
-            TemporaryDirectory = self.setup_mocks(*args)
+            TemporaryDirectory, team_name = self.setup_mocks(*args)
 
         environment = 'live'
 
@@ -437,7 +440,7 @@ class TestDestroyCLI(unittest.TestCase):
                 '-backend-config=key=terraform.tfstate',
                 (
                     '-backend-config=workspace_key_prefix='
-                    f'your-team/{component_name}'
+                    f'{team_name}/{component_name}'
                 ),
                 '-backend-config=dynamodb_table=tflocks-table',
                 '-backend-config=access_key=dummy-access-key-id',
@@ -469,7 +472,7 @@ class TestDestroyCLI(unittest.TestCase):
         check_call_state, mock_assumed_session, time, aws_access_key_id, \
             aws_secret_access_key, aws_session_token, component_name, \
             check_call_destroy, remove_state_mock_s3, \
-            TemporaryDirectory = self.setup_mocks(*args)
+            TemporaryDirectory, team_name = self.setup_mocks(*args)
 
         environment = 'live'
 
@@ -490,7 +493,7 @@ class TestDestroyCLI(unittest.TestCase):
                 '-backend-config=key=terraform.tfstate',
                 (
                     '-backend-config=workspace_key_prefix='
-                    f'your-team/{component_name}'
+                    f'{team_name}/{component_name}'
                 ),
                 '-backend-config=dynamodb_table=tflocks-table',
                 '-backend-config=access_key={}'.format(aws_access_key_id),

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -59,6 +59,7 @@ class TestReleaseCLI(unittest.TestCase):
             },
             'terraform-backend-s3-bucket': 'tfstate-bucket',
             'terraform-backend-s3-dynamodb-table': 'tflocks-table',
+            'classic-metadata-handling': True,
         })
 
         mock_s3_resource = Mock()
@@ -192,6 +193,7 @@ class TestReleaseCLI(unittest.TestCase):
             },
             'terraform-backend-s3-bucket': 'tfstate-bucket',
             'terraform-backend-s3-dynamodb-table': 'tflocks-table',
+            'classic-metadata-handling': True,
         })
 
         mock_s3_resource = Mock()

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -61,6 +61,7 @@ class TestReleaseCLI(unittest.TestCase):
             },
             'terraform-backend-s3-bucket': 'tfstate-bucket',
             'terraform-backend-s3-dynamodb-table': 'tflocks-table',
+            'classic-metadata-handling': True,
         })
 
         mock_s3_resource = Mock()

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -66,6 +66,7 @@ class TestReleaseCLI(unittest.TestCase):
             },
             'terraform-backend-s3-bucket': 'tfstate-bucket',
             'terraform-backend-s3-dynamodb-table': 'tflocks-table',
+            'classic-metadata-handling': True,
         })
 
         mock_s3_resource = Mock()


### PR DESCRIPTION
The initial update I did only did it for the Terraform state bucket.

This fixes that mistake and adds the `team/` prefix to the Lambda and release bucket paths.