### PR TITLE
Check for metadata handling before creating repo

### DIFF
--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -31,9 +31,9 @@ class ReleasePlugin:
         self._on_docker_build()
 
         if self._release.version:
-            self._ensure_ecr_repo_exists()
-            self._ensure_ecr_policy_set()
-            # self._ensure_ecr_lifecycle_policy_set()
+            if self._account_scheme.classic_metadata_handling:
+                self._ensure_ecr_repo_exists()
+                self._ensure_ecr_policy_set()
             self._docker_login()
             self._docker_push(self._image_name)
             self._docker_tag_latest()

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -59,6 +59,7 @@ class TestRelease(unittest.TestCase):
                     'role': 'dummy'
                 }
             },
+            'classic-metadata-handling': True,
             'release-account': 'dummy',
             'default-region': self._region,
             'release-bucket': 'dummy',
@@ -279,6 +280,22 @@ class TestRelease(unittest.TestCase):
                 repositoryName=component_name
             )
 
+    @given(text(alphabet=IDENTIFIER_ALPHABET, min_size=8, max_size=16))
+    def test_ecr_repo_creation_skipped_for_new_metadata_handling(
+        self, component_name,
+    ):
+        # Given
+        self._plugin._account_scheme.classic_metadata_handling = False
+        self._release.component_name = component_name
+
+        with patch('cdflow_commands.plugins.ecs.check_call'):
+            # When
+            self._plugin.create()
+
+            # Then
+            self._ecr_client.create_repository.assert_not_called()
+            self._ecr_client.describe_repositories.assert_not_called()
+
     @given(text(alphabet=ascii_letters, min_size=8, max_size=16))
     def test_exception_re_raised(self, error_code):
         # Given
@@ -336,6 +353,7 @@ class TestRelease(unittest.TestCase):
                 }
                 for account in accounts
             },
+            'classic-metadata-handling': True,
             'release-account': accounts[0]['alias'],
             'default-region': self._region,
             'release-bucket': 'dummy',


### PR DESCRIPTION
The docker repos are created out-of-band for the newer, release account metadata handling so the creation here needs to be skipped.