### PR TITLE
Forward account scheme

### DIFF
--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -74,7 +74,8 @@ def _run(argv):
     root_session = Session()
 
     account_scheme = build_account_scheme_s3(
-        root_session.resource('s3'), manifest.account_scheme_url, manifest.team
+        root_session.resource('s3'), manifest.account_scheme_url,
+        manifest.team, get_component_name(args['--component']),
     )
     root_session = Session(region_name=account_scheme.default_region)
     release_account_session = assume_role(

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -136,7 +136,7 @@ def build_account_scheme_s3(s3_resource, s3_url, team):
     )
     upgrade = account_scheme.raw_scheme.get('upgrade-account-scheme')
 
-    if upgrade:
+    if upgrade and team in upgrade['team-whitelist']:
         new_s3_url = upgrade['new-url']
         new_bucket, new_key = parse_s3_url(new_s3_url)
         account_scheme = AccountScheme.create(

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -131,9 +131,19 @@ def fetch_account_scheme(s3_resource, bucket, key):
 
 def build_account_scheme_s3(s3_resource, s3_url, team):
     bucket, key = parse_s3_url(s3_url)
-    return AccountScheme.create(
+    account_scheme = AccountScheme.create(
         fetch_account_scheme(s3_resource, bucket, key), team
     )
+    upgrade = account_scheme.raw_scheme.get('upgrade-account-scheme')
+
+    if upgrade:
+        new_s3_url = upgrade['new-url']
+        new_bucket, new_key = parse_s3_url(new_s3_url)
+        account_scheme = AccountScheme.create(
+            fetch_account_scheme(s3_resource, new_bucket, new_key), team
+        )
+
+    return account_scheme
 
 
 def build_account_scheme_file(filename, team):

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -142,6 +142,10 @@ def build_account_scheme_s3(s3_resource, s3_url, team):
         account_scheme = AccountScheme.create(
             fetch_account_scheme(s3_resource, new_bucket, new_key), team
         )
+        logger.warning(
+            'Account scheme is being upgraded. Manually update '
+            f'account_scheme_url in cdflow.yml to {new_s3_url}'
+        )
 
     return account_scheme
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -129,6 +129,7 @@ class TestCliBuildPlugin(unittest.TestCase):
 
 class TestRoles(unittest.TestCase):
 
+    @patch('cdflow_commands.config.check_output')
     @patch('cdflow_commands.cli.load_manifest')
     @patch('cdflow_commands.cli.run_release')
     @patch('cdflow_commands.cli.assume_role')
@@ -136,7 +137,7 @@ class TestRoles(unittest.TestCase):
     @patch('cdflow_commands.cli.Session')
     def test_release_assumes_release_account_role(
         self, Session, build_account_scheme_s3, assume_role, run_release,
-        load_manifest
+        load_manifest, check_output,
     ):
 
         # Given
@@ -149,6 +150,8 @@ class TestRoles(unittest.TestCase):
         account_scheme.release_account.role = 'test-role'
         account_scheme.default_region = 'eu-west-12'
         build_account_scheme_s3.return_value = account_scheme
+        check_output.return_value = 'git@github.com:org/component.git\n'\
+            .encode('utf-8')
 
         # When
         cli._run([

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -552,9 +552,10 @@ class TestAccountSchemeHandling(unittest.TestCase):
             {'Body': second_mock_s3_body}
         )
 
-        account_scheme = config.build_account_scheme_s3(
-            s3_resource, s3_url, 'a-team'
-        )
+        with self.assertLogs('cdflow_commands.logger', level='WARN') as logs:
+            account_scheme = config.build_account_scheme_s3(
+                s3_resource, s3_url, 'a-team'
+            )
 
         assert account_scheme.release_account.id == '123456789'
         assert account_scheme.account_ids == ['123456789']
@@ -565,6 +566,13 @@ class TestAccountSchemeHandling(unittest.TestCase):
         s3_resource.Object.assert_any_call(
             'second_s3_bucket', 'second_s3_key'
         )
+
+        assert (
+            'WARNING:cdflow_commands.logger:'
+            'Account scheme is being upgraded. Manually update '
+            'account_scheme_url in cdflow.yml to '
+            's3://second_s3_bucket/second_s3_key'
+        ) in logs.output
 
     @given(fixed_dictionaries({
         'filename': text(min_size=1),

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,4 +1,5 @@
 import yaml
+import json
 import unittest
 from datetime import datetime
 from io import TextIOWrapper
@@ -490,6 +491,79 @@ class TestAccountSchemeHandling(unittest.TestCase):
 
         s3_resource.Object.assert_called_once_with(
             *fixtures['s3_bucket_and_key']
+        )
+
+    def test_forward_to_new_account_scheme_from_s3(self):
+        s3_resource = Mock()
+
+        first_s3_bucket = 'firstbucket'
+        first_s3_key = 'firstkey'
+        s3_url = f's3://{first_s3_bucket}/{first_s3_key}'
+
+        first_mock_s3_body = Mock()
+        first_mock_s3_body.read.return_value = '''
+            {
+              "accounts": {
+                "myorgdev": {
+                  "id": "222222222222",
+                  "role": "admin"
+                },
+                "myorgprod": {
+                  "id": "111111111111",
+                  "role": "admin"
+                }
+              },
+              "classic-metadata-handling": true,
+              "upgrade-account-scheme": {
+                "new-url": "s3://second_s3_bucket/second_s3_key"
+              },
+              "release-account": "myorgdev",
+              "release-bucket": "myorg-account-resources",
+              "environments": {
+                "live": "myorgprod",
+                "*": "myorgdev"
+              },
+              "default-region": "eu-west-12",
+              "terraform-backend-s3-bucket": "tfstate-bucket",
+              "terraform-backend-s3-dynamodb-table": "tflocks-table"
+            }
+        '''
+
+        second_mock_s3_body = Mock()
+        second_mock_s3_body.read.return_value = json.dumps({
+            'accounts': {
+                '{team}-release-account-{team}': {
+                    'id': '123456789',
+                    'role': '{team}-role-{team}',
+                }
+            },
+            'release-bucket': '{team}-release-bucket-{team}',
+            'lambda-bucket': '{team}-lambda-bucket-{team}',
+            'release-account': '{team}-release-account-{team}',
+            'default-region': '{team}-region-{team}',
+            'environments': {},
+            'terraform-backend-s3-bucket': '{team}-backend-bucket-{team}',
+            'terraform-backend-s3-dynamodb-table':
+            '{team}-backend-dynamo-{team}',
+        })
+
+        s3_resource.Object.return_value.get.side_effect = (
+            {'Body': first_mock_s3_body},
+            {'Body': second_mock_s3_body}
+        )
+
+        account_scheme = config.build_account_scheme_s3(
+            s3_resource, s3_url, 'a-team'
+        )
+
+        assert account_scheme.release_account.id == '123456789'
+        assert account_scheme.account_ids == ['123456789']
+
+        s3_resource.Object.assert_any_call(
+            first_s3_bucket, first_s3_key
+        )
+        s3_resource.Object.assert_any_call(
+            'second_s3_bucket', 'second_s3_key'
         )
 
     @given(fixed_dictionaries({


### PR DESCRIPTION
Add the facility to use a new account scheme, pointed to by the one configured in `cdflow.yml`.

Will upgrade to the new scheme if **either**:
 - team is whitelisted **OR**
 - component is whitelisted