### PR TITLE
Region support in accounts

### DIFF
--- a/cdflow_commands/account.py
+++ b/cdflow_commands/account.py
@@ -1,13 +1,13 @@
 from collections import defaultdict
+from dataclasses import dataclass
 
 
+@dataclass(frozen=True, order=True)
 class Account:
-
-    def __init__(self, alias, id, role, region):
-        self.alias = alias
-        self.id = id
-        self.role = role
-        self.region = region
+    alias: str
+    id: str
+    role: str
+    region: str
 
 
 def replace_team(scheme, team):

--- a/cdflow_commands/account.py
+++ b/cdflow_commands/account.py
@@ -3,10 +3,11 @@ from collections import defaultdict
 
 class Account:
 
-    def __init__(self, alias, id, role):
+    def __init__(self, alias, id, role, region):
         self.alias = alias
         self.id = id
         self.role = role
+        self.region = region
 
 
 def replace_team(scheme, team):
@@ -67,8 +68,14 @@ class AccountScheme:
     @classmethod
     def create(cls, raw_scheme, team):
         scheme = replace_team(raw_scheme, team)
+        default_region = scheme['default-region']
         accounts = {
-            alias: Account(alias, account['id'], account['role'])
+            alias: Account(
+                alias,
+                account['id'],
+                account['role'],
+                account.get('region', default_region),
+            )
             for alias, account
             in scheme['accounts'].items()
         }
@@ -91,7 +98,7 @@ class AccountScheme:
             scheme['release-bucket'],
             scheme.get('lambda-bucket', ''),
             scheme.get('lambda-buckets', {}),
-            scheme['default-region'],
+            default_region,
             environment_mapping,
             scheme.get('classic-metadata-handling', False),
             scheme.get('terraform-backend-s3-bucket', None),

--- a/cdflow_commands/cli.py
+++ b/cdflow_commands/cli.py
@@ -79,8 +79,7 @@ def _run(argv):
     )
     root_session = Session(region_name=account_scheme.default_region)
     release_account_session = assume_role(
-        root_session, account_scheme.release_account.id,
-        account_scheme.release_account.role, account_scheme.default_region,
+        root_session, account_scheme.release_account,
     )
 
     if args['release']:
@@ -158,9 +157,7 @@ def assume_infrastructure_account_role(
     account = account_scheme.account_for_environment(environment)
     logger.debug(f'Assuming role {account.role} in {account.id}')
 
-    return assume_role(
-        root_session, account.id, account.role, account_scheme.default_region,
-    )
+    return assume_role(root_session, account)
 
 
 def run_non_release_command_on_release(

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -54,23 +54,23 @@ def load_manifest():
         )
 
 
-def assume_role(root_session, account_id, role_name, region=None):
+def assume_role(root_session, account):
     sts = root_session.client('sts')
     session_name = get_role_session_name(sts)
     logger.debug(
         "Assuming role arn:aws:iam::{}:role/admin with session {}".format(
-            account_id, session_name
+            account.id, session_name
         )
     )
     response = sts.assume_role(
-        RoleArn=f'arn:aws:iam::{account_id}:role/{role_name}',
+        RoleArn=f'arn:aws:iam::{account.id}:role/{account.role}',
         RoleSessionName=session_name,
     )
     return Session(
         response['Credentials']['AccessKeyId'],
         response['Credentials']['SecretAccessKey'],
         response['Credentials']['SessionToken'],
-        region if region else root_session.region_name,
+        account.region,
     )
 
 

--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -77,6 +77,7 @@ def assume_role(root_session, account):
 def env_with_aws_credetials(env, boto_session):
     result = env.copy()
     credentials = boto_session.get_credentials()
+    logger.debug(f'Setting region to {boto_session.region_name}')
     result.update({
         'AWS_ACCESS_KEY_ID': credentials.access_key,
         'AWS_SECRET_ACCESS_KEY': credentials.secret_key,

--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -63,7 +63,7 @@ class ReleasePlugin:
     def _image_name(self):
         return '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
             self._account_scheme.release_account.id,
-            self._account_scheme.default_region,
+            self._account_scheme.release_account.region,
             self._release.component_name,
             self._release.version or 'dev'
         )
@@ -72,7 +72,7 @@ class ReleasePlugin:
     def _latest_image_name(self):
         return '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
             self._account_scheme.release_account.id,
-            self._account_scheme.default_region,
+            self._account_scheme.release_account.region,
             self._release.component_name,
             'latest'
         )

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -79,7 +79,7 @@ class TestRelease(unittest.TestCase):
         'region': text(alphabet=IDENTIFIER_ALPHABET, min_size=1, max_size=10),
         'account_id': text(alphabet=digits, min_size=12, max_size=12),
     }))
-    def test_builds_container(self, fixtures):
+    def test_builds_container_and_uses_release_account_region(self, fixtures):
         # Given
         component_name = fixtures['component_name']
         region = fixtures['region']
@@ -93,11 +93,12 @@ class TestRelease(unittest.TestCase):
             'accounts': {
                 'dummy': {
                     'id': account_id,
-                    'role': 'dummy'
+                    'role': 'dummy',
+                    'region': region,
                 }
             },
             'release-account': 'dummy',
-            'default-region': region,
+            'default-region': 'eu-west-42',
             'release-bucket': 'dummy',
             'environments': {
                 'live': 'dummy',

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -148,6 +148,7 @@ class TestRoles(unittest.TestCase):
         account_scheme = Mock()
         account_scheme.release_account.id = '1234567890'
         account_scheme.release_account.role = 'test-role'
+        account_scheme.release_account.region_name = 'eu-west-13'
         account_scheme.default_region = 'eu-west-12'
         build_account_scheme_s3.return_value = account_scheme
         check_output.return_value = 'git@github.com:org/component.git\n'\
@@ -160,7 +161,7 @@ class TestRoles(unittest.TestCase):
 
         # Then
         assume_role.assert_called_once_with(
-            root_session, '1234567890', 'test-role', 'eu-west-12'
+            root_session, account_scheme.release_account,
         )
         run_release.assert_called_once_with(
             release_account_session, account_scheme, ANY,
@@ -188,6 +189,7 @@ class TestRoles(unittest.TestCase):
         infrastructure_account = Mock()
         infrastructure_account.id = '0987654321'
         infrastructure_account.role = 'test-role'
+        infrastructure_account.region = 'eu-west-13'
         account_scheme.account_for_environment.return_value = \
             infrastructure_account
         build_account_scheme_file.return_value = account_scheme
@@ -204,7 +206,7 @@ class TestRoles(unittest.TestCase):
         # Then
         account_scheme.account_for_environment.assert_called_once_with('ci')
         assume_role.assert_called_once_with(
-            root_session, '0987654321', 'test-role', 'eu-west-12'
+            root_session, infrastructure_account,
         )
         run_deploy.assert_called_once_with(
             ANY, account_scheme, release_account_session,
@@ -232,6 +234,7 @@ class TestRoles(unittest.TestCase):
         infrastructure_account = Mock()
         infrastructure_account.id = '0987654321'
         infrastructure_account.role = 'test-role'
+        infrastructure_account.region = 'eu-west-13'
         account_scheme.account_for_environment.return_value = \
             infrastructure_account
         build_account_scheme_file.return_value = account_scheme
@@ -248,7 +251,7 @@ class TestRoles(unittest.TestCase):
         # Then
         account_scheme.account_for_environment.assert_called_once_with('ci')
         assume_role.assert_called_once_with(
-            root_session, '0987654321', 'test-role', 'eu-west-12'
+            root_session, infrastructure_account,
         )
         run_deploy.assert_called_once_with(
             ANY, account_scheme, infrastructure_account_session,


### PR DESCRIPTION
Introduce a `"region"` key for accounts in the account scheme. If present, a session will be created in that region instead of the `"default-region"` specified in the account scheme.