### PR TITLE
Removes --cache-from

### DIFF
--- a/cdflow_commands/plugins/ecs.py
+++ b/cdflow_commands/plugins/ecs.py
@@ -24,7 +24,6 @@ class ReleasePlugin:
     def create(self):
         check_call([
             'docker', 'build',
-            '--cache-from', self._latest_image_name,
             '-t', self._image_name, '.'
         ])
 

--- a/test/plugins/test_ecs_release.py
+++ b/test/plugins/test_ecs_release.py
@@ -111,10 +111,6 @@ class TestRelease(unittest.TestCase):
             account_id, region, component_name, 'dev'
         )
 
-        latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
-            account_id, region, component_name, 'latest'
-        )
-
         plugin = ReleasePlugin(release, account_scheme)
 
         with patch('cdflow_commands.plugins.ecs.check_call') as check_call:
@@ -127,7 +123,6 @@ class TestRelease(unittest.TestCase):
             check_call.assert_called_once_with([
                 'docker',
                 'build',
-                '--cache-from', latest_image_name,
                 '-t', image_name, '.'
             ])
 
@@ -146,14 +141,9 @@ class TestRelease(unittest.TestCase):
                 self._account_id, self._region, self._component_name, version
             )
 
-            latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
-                self._account_id, self._region, self._component_name, 'latest'
-            )
-
             check_call.assert_any_call([
                 'docker',
                 'build',
-                '--cache-from', latest_image_name,
                 '-t', image_name, '.'
             ])
 

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -121,12 +121,6 @@ class TestReleaseCLI(unittest.TestCase):
             component_name,
             version
         )
-        latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
-            123456789,
-            'us-north-4',
-            component_name,
-            'latest'
-        )
 
         cli.run([
             'release', '--platform-config', 'path/to/config',
@@ -142,7 +136,6 @@ class TestReleaseCLI(unittest.TestCase):
 
         check_call.assert_any_call([
             'docker', 'build',
-            '--cache-from', latest_image_name,
             '-t', image_name, '.'
         ])
         check_call.assert_any_call(['docker', 'push', image_name])
@@ -262,16 +255,9 @@ class TestReleaseCLI(unittest.TestCase):
             component_name,
             version
         )
-        latest_image_name = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(
-            123456789,
-            'us-north-4',
-            component_name,
-            'latest'
-        )
 
         check_call.assert_any_call([
             'docker', 'build',
-            '--cache-from', latest_image_name,
             '-t', image_name, '.'
         ])
         check_call.assert_any_call(['docker', 'push', image_name])


### PR DESCRIPTION
Fails to get existing layers from previous builds causing an increase of build time when running cdflow release.

PLAT-1851