### PR TITLE
Set session duration to 1 hour when running as an assumed role

### DIFF
--- a/cdflow_commands/config.py
+++ b/cdflow_commands/config.py
@@ -62,10 +62,15 @@ def assume_role(root_session, account):
             account.id, account.role, session_name
         )
     )
+    session_duration = get_session_duration(sts)
+    logger.debug(
+        f"Session duration is set to {session_duration}"
+    )
+
     response = sts.assume_role(
         RoleArn=f'arn:aws:iam::{account.id}:role/{account.role}',
         RoleSessionName=session_name,
-        DurationSeconds=14400,
+        DurationSeconds=session_duration,
     )
     return Session(
         response['Credentials']['AccessKeyId'],
@@ -89,6 +94,14 @@ def env_with_aws_credetials(env, boto_session):
             'AWS_SESSION_TOKEN': credentials.token,
         })
     return result
+
+
+def get_session_duration(sts_client):
+    caller_response = sts_client.get_caller_identity()
+    if 'assumed-role' in caller_response.get('Arn'):
+        return 3600
+    else:
+        return 14400
 
 
 def get_role_session_name(sts_client):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -142,7 +142,7 @@ class TestAssumeRole(unittest.TestCase):
         mock_sts.get_caller_identity.return_value = {
             u'UserId': user_id,
             'Arn': f'role/{user_id}'
-        }        
+        }
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',
@@ -180,7 +180,6 @@ class TestAssumeRole(unittest.TestCase):
             region,
         )
 
-
     @patch('cdflow_commands.config.Session')
     def test_assumed_role_has_correct_session_duration(self, MockSession):
 
@@ -195,7 +194,7 @@ class TestAssumeRole(unittest.TestCase):
         mock_sts.get_caller_identity.return_value = {
             u'UserId': user_id,
             'Arn': f'arn:aws:sts::123456789:assumed-role/admin/{user_id}'
-        }        
+        }
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',
@@ -235,7 +234,6 @@ class TestGetRoleSessionName(unittest.TestCase):
         sts_client.get_caller_identity.return_value = {
             u'Account': '111111111111',
             u'UserId': user_id,
-            'Arn': 'dummy_arn',
             'ResponseMetadata': {
                 'RetryAttempts': 0,
                 'HTTPStatusCode': 200,
@@ -260,7 +258,6 @@ class TestGetRoleSessionName(unittest.TestCase):
         sts_client.get_caller_identity.return_value = {
             u'Account': '111111111111',
             u'UserId': user_id,
-            'Arn': 'dummy_arn',
             'ResponseMetadata': {
                 'RetryAttempts': 0,
                 'HTTPStatusCode': 200,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -139,7 +139,10 @@ class TestAssumeRole(unittest.TestCase):
 
         mock_sts = Mock()
         user_id = 'foo'
-        mock_sts.get_caller_identity.return_value = {u'UserId': user_id}
+        mock_sts.get_caller_identity.return_value = {
+            u'UserId': user_id,
+            'Arn': f'role/{user_id}'
+        }        
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',
@@ -169,11 +172,58 @@ class TestAssumeRole(unittest.TestCase):
             RoleArn='arn:aws:iam::{}:role/{}'.format(account_id, role_name),
             RoleSessionName=user_id,
         )
+
         MockSession.assert_called_once_with(
             'dummy-access-key-id',
             'dummy-secret-access-key',
             'dummy-session-token',
             region,
+        )
+
+
+    @patch('cdflow_commands.config.Session')
+    def test_assumed_role_has_correct_session_duration(self, MockSession):
+
+        mock_root_session = Mock()
+        mock_root_session.region_name = 'eu-west-12'
+
+        mock_session = Mock()
+        MockSession.return_value = mock_session
+
+        mock_sts = Mock()
+        user_id = 'foo'
+        mock_sts.get_caller_identity.return_value = {
+            u'UserId': user_id,
+            'Arn': f'arn:aws:sts::123456789:assumed-role/admin/{user_id}'
+        }        
+        mock_sts.assume_role.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'dummy-access-key-id',
+                'SecretAccessKey': 'dummy-secret-access-key',
+                'SessionToken': 'dummy-session-token',
+                'Expiration': datetime(2015, 1, 1)
+            },
+            'AssumedRoleUser': {
+                'AssumedRoleId': 'dummy-assumed-role-id',
+                'Arn': 'dummy-arn'
+            },
+            'PackedPolicySize': 123
+        }
+        mock_root_session.client.return_value = mock_sts
+
+        account_id = 123456789
+        role_name = 'test-role-name'
+        region = 'us-east-99'
+        account = Account('account-alias', account_id, role_name, region)
+        session = config.assume_role(mock_root_session, account)
+
+        assert session is mock_session
+
+        mock_root_session.client.assert_called_once_with('sts')
+        mock_sts.assume_role.assert_called_once_with(
+            DurationSeconds=3600,
+            RoleArn='arn:aws:iam::{}:role/{}'.format(account_id, role_name),
+            RoleSessionName=user_id,
         )
 
 
@@ -185,6 +235,7 @@ class TestGetRoleSessionName(unittest.TestCase):
         sts_client.get_caller_identity.return_value = {
             u'Account': '111111111111',
             u'UserId': user_id,
+            'Arn': 'dummy_arn',
             'ResponseMetadata': {
                 'RetryAttempts': 0,
                 'HTTPStatusCode': 200,
@@ -209,6 +260,7 @@ class TestGetRoleSessionName(unittest.TestCase):
         sts_client.get_caller_identity.return_value = {
             u'Account': '111111111111',
             u'UserId': user_id,
+            'Arn': 'dummy_arn',
             'ResponseMetadata': {
                 'RetryAttempts': 0,
                 'HTTPStatusCode': 200,

--- a/test/test_integration_cli_deploy.py
+++ b/test/test_integration_cli_deploy.py
@@ -85,7 +85,7 @@ class TestDeployCLI(unittest.TestCase):
         mock_sts_client.get_caller_identity.return_value = {
             u'UserId': 'foo',
             'Arn': 'dummy_arn'
-        }        
+        }
         mock_sts_client.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key',

--- a/test/test_integration_cli_deploy.py
+++ b/test/test_integration_cli_deploy.py
@@ -82,7 +82,10 @@ class TestDeployCLI(unittest.TestCase):
             else mock_metadata_file_open
 
         mock_sts_client = Mock()
-        mock_sts_client.get_caller_identity.return_value = {'UserId': 'foo'}
+        mock_sts_client.get_caller_identity.return_value = {
+            u'UserId': 'foo',
+            'Arn': 'dummy_arn'
+        }        
         mock_sts_client.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key',

--- a/test/test_integration_cli_destroy.py
+++ b/test/test_integration_cli_destroy.py
@@ -83,7 +83,10 @@ class TestDestroyCLI(unittest.TestCase):
             else mock_metadata_file_open
 
         mock_sts_client = Mock()
-        mock_sts_client.get_caller_identity.return_value = {'UserId': 'foo'}
+        mock_sts_client.get_caller_identity.return_value = {
+            u'UserId': 'foo',
+            'Arn': 'dummy_arn'
+        }
         mock_sts_client.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key',

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -84,7 +84,10 @@ class TestReleaseCLI(unittest.TestCase):
 
         mock_sts = Mock()
         user_id = 'foo'
-        mock_sts.get_caller_identity.return_value = {u'UserId': user_id}
+        mock_sts.get_caller_identity.return_value = {
+            u'UserId': user_id,
+            'Arn': 'dummy_arn'
+        }
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',
@@ -211,7 +214,10 @@ class TestReleaseCLI(unittest.TestCase):
         Session_from_config.return_value = mock_session
 
         mock_sts = Mock()
-        mock_sts.get_caller_identity.return_value = {'UserId': 'foo'}
+        mock_sts.get_caller_identity.return_value = {
+            u'UserId': 'foo',
+            'Arn': 'dummy_arn'
+        }        
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',

--- a/test/test_integration_cli_ecs.py
+++ b/test/test_integration_cli_ecs.py
@@ -217,7 +217,7 @@ class TestReleaseCLI(unittest.TestCase):
         mock_sts.get_caller_identity.return_value = {
             u'UserId': 'foo',
             'Arn': 'dummy_arn'
-        }        
+        }
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',

--- a/test/test_integration_cli_infrastructure.py
+++ b/test/test_integration_cli_infrastructure.py
@@ -71,7 +71,10 @@ class TestReleaseCLI(unittest.TestCase):
         mock_root_session.resource.return_value = mock_s3_resource
 
         mock_sts = Mock()
-        mock_sts.get_caller_identity.return_value = {'UserId': 'foo'}
+        mock_sts.get_caller_identity.return_value = {
+            u'UserId': 'foo',
+            'Arn': 'dummy_arn'
+        }
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -94,7 +94,7 @@ class TestReleaseCLI(unittest.TestCase):
         mock_sts.get_caller_identity.return_value = {
             u'UserId': 'foo',
             'Arn': 'dummy_arn'
-        }        
+        }
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',

--- a/test/test_integration_cli_lambda.py
+++ b/test/test_integration_cli_lambda.py
@@ -91,7 +91,10 @@ class TestReleaseCLI(unittest.TestCase):
         Session_from_config.return_value = mock_session
 
         mock_sts = Mock()
-        mock_sts.get_caller_identity.return_value = {'UserId': 'foo'}
+        mock_sts.get_caller_identity.return_value = {
+            u'UserId': 'foo',
+            'Arn': 'dummy_arn'
+        }        
         mock_sts.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key-id',

--- a/test/test_integration_cli_shell.py
+++ b/test/test_integration_cli_shell.py
@@ -79,7 +79,10 @@ class TestCliShell(unittest.TestCase):
         mock_account_scheme_open.__enter__.return_value = mock_account_scheme
 
         mock_sts_client = Mock()
-        mock_sts_client.get_caller_identity.return_value = {'UserId': 'foo'}
+        mock_sts_client.get_caller_identity.return_value = {
+            u'UserId': 'foo',
+            'Arn': 'dummy_arn'
+        }
         mock_sts_client.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key',
@@ -201,7 +204,10 @@ class TestCliShell(unittest.TestCase):
         mock_account_scheme_open.__enter__.return_value = mock_account_scheme
 
         mock_sts_client = Mock()
-        mock_sts_client.get_caller_identity.return_value = {'UserId': 'foo'}
+        mock_sts_client.get_caller_identity.return_value = {
+            u'UserId': 'foo',
+            'Arn': 'dummy_arn'
+        }
         mock_sts_client.assume_role.return_value = {
             'Credentials': {
                 'AccessKeyId': 'dummy-access-key',


### PR DESCRIPTION
There is a session duration hard limit in AWS of 1 hour when
assuming a role when you have already assumed a role, it's
called role chaining.